### PR TITLE
Fix parsing error when fetching from db

### DIFF
--- a/desdeo/problem/schema.py
+++ b/desdeo/problem/schema.py
@@ -136,6 +136,8 @@ def parse_list_to_mathjson(cls: "TensorVariable", v: Tensor | None) -> list:
         return v
     # recursively parse into a MathJSON representation
     if isinstance(v, list) and len(v) > 0:
+        if v[0] == "List":
+            return v
         if isinstance(v[0], list):
             # recursive case, encountered list
             return ["List", *[parse_list_to_mathjson(TensorVariable, v_element) for v_element in v]]


### PR DESCRIPTION
Problem: 

- In db_init, when saving problems to db, parse_list_to_mathjson has been run so the tensor constants are already saved as mathjson in db. When problem is fetched from db, it tries to run parse_list_to_mathjson again.

-> In parse_list_to_mathjson of problem schema, if the first element is already 'List', parsing is not necessary anymore.