### PR TITLE
bug? fix for enautilus and scaling delta for group scalas

### DIFF
--- a/desdeo/mcdm/enautilus.py
+++ b/desdeo/mcdm/enautilus.py
@@ -46,7 +46,7 @@ class ENautilusResult(BaseModel):
 
     current_iteration: int = Field(description="Number of the current iteration.")
     iterations_left: int = Field(description="Number of iterations left.")
-    intermediate_points: list[str[str, float]] = Field(description="New intermediate points")
+    intermediate_points: list[dict[str, float]] = Field(description="New intermediate points")
     reachable_bounds: list[tuple[float]] = Field(
         description="Bounds of the solutions reachable from each intermediate point."
     )

--- a/desdeo/tools/scalarization.py
+++ b/desdeo/tools/scalarization.py
@@ -332,7 +332,8 @@ def add_group_asf_diff(
     reference_points: list[dict[str, float]],
     ideal: dict[str, float] | None = None,
     nadir: dict[str, float] | None = None,
-    delta: float = 1e-6,
+    #delta: float = 1e-6,
+    delta: dict[str, float] | None = None, # TODO: fix none issue
     rho: float = 1e-6,
 ) -> tuple[Problem, str]:
     r"""Add the differentiable variant of the achievement scalarizing function for multiple decision makers.
@@ -404,7 +405,7 @@ def add_group_asf_diff(
 
     # calculate the weights
     weights = {
-        obj.symbol: 1 / (nadir_point[obj.symbol] - (ideal_point[obj.symbol] - delta)) for obj in problem.objectives
+        obj.symbol: 1 / (nadir_point[obj.symbol] - (ideal_point[obj.symbol] - delta[obj.symbol])) for obj in problem.objectives
     }
 
     # form the constaint and augmentation expressions
@@ -2024,7 +2025,8 @@ def add_group_stom_sf_diff(
     reference_points: list[dict[str, float]],
     ideal: dict[str, float] | None = None,
     rho: float = 1e-6,
-    delta: float = 1e-6,
+    delta: dict[str, float] | None = None, # TODO: fix none issue
+    #delta: float = 1e-6,
 ) -> tuple[Problem, str]:
     r"""Adds the differentiable variant of the multiple decision maker variant of the STOM scalarizing function.
 
@@ -2090,7 +2092,7 @@ def add_group_stom_sf_diff(
         corrected_rp = get_corrected_reference_point(problem, reference_point)
         weights.append(
             {
-                obj.symbol: 1 / (corrected_rp[obj.symbol] - (ideal_point[obj.symbol] - delta))
+                obj.symbol: 1 / (corrected_rp[obj.symbol] - (ideal_point[obj.symbol] - delta[obj.symbol]))
                 for obj in problem.objectives
             }
         )
@@ -2101,7 +2103,7 @@ def add_group_stom_sf_diff(
         rp = {}
         for obj in problem.objectives:
             rp[obj.symbol] = (
-                f"{weights[i][obj.symbol]} * ({obj.symbol}_min - {ideal_point[obj.symbol] - delta}) - _alpha"
+                f"{weights[i][obj.symbol]} * ({obj.symbol}_min - {ideal_point[obj.symbol] - delta[obj.symbol]}) - _alpha"
             )
         con_terms.append(rp)
 
@@ -2524,7 +2526,8 @@ def add_group_guess_sf_diff(
     reference_points: list[dict[str, float]],
     nadir: dict[str, float] | None = None,
     rho: float = 1e-6,
-    delta: float = 1e-6,
+    delta: dict[str, float] | None = None, # TODO: fix none issue
+    #delta: float = 1e-6,
 ) -> tuple[Problem, str]:
     r"""Adds the differentiable variant of the multiple decision maker variant of the GUESS scalarizing function.
 
@@ -2590,7 +2593,7 @@ def add_group_guess_sf_diff(
         corrected_rp = get_corrected_reference_point(problem, reference_point)
         weights.append(
             {
-                obj.symbol: 1 / ((nadir_point[obj.symbol] + delta) - (corrected_rp[obj.symbol]))
+                obj.symbol: 1 / ((nadir_point[obj.symbol] + delta[obj.symbol]) - (corrected_rp[obj.symbol]))
                 for obj in problem.objectives
             }
         )


### PR DESCRIPTION
New E-NAUTILUS has an error with intermediate_points type. I changed it to be  list[dict[str, float]] = Field(description="New intermediate points") and now it runs. If this is not intended change, revert this. 

For group scalarization functions, delta is now a dictionary for each objective function to be scaled before giving it as a parameter. Needed stuff for GNIMBUS, feel free to make more lasting fix.