### PR TITLE
[Do Not Accept] Benchmarks from external suites

### DIFF
--- a/BenchExp/experiment.ipynb
+++ b/BenchExp/experiment.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a5aefbf8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/bhupindersaini/Projects/DESDEO/desdeo/__init__.py:9: UserWarning: \n",
+      "            \n",
+      "The following required highly recommended executables cannot be found: bonmin, cbc, ipopt\n",
+      "\n",
+      "            DESDEO relies on powerful 3rd party solvers to solve multiobjective\n",
+      "            optimization problems.  Without these solvers, sub-optimal defaults\n",
+      "            will be used instead, which can lead to not optimal, or even wrong,\n",
+      "            results.\n",
+      "\n",
+      "            It is highly recommended to have these solvers available\n",
+      "            in the environment DESDEO is utilized!\n",
+      "\n",
+      "            For more information, see DESDEO's documentation: https://desdeo.readthedocs.io/en/latest/howtoguides/installing/#third-party-optimizers\n",
+      "            \n",
+      "  _check_executables(required_executables)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import polars as pl\n",
+    "from pymoo.problems import get_problem\n",
+    "\n",
+    "from desdeo.problem import Evaluator, Objective, Problem, Simulator, Variable, testproblems\n",
+    "from desdeo.problem.testproblems import dtlz2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c5173cca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ignore this mess.\n",
+    "\n",
+    "\n",
+    "def simulator_problem(problem_name: str, n_vars: int, n_objs: int, server=False) -> Problem:\n",
+    "    # define all the variables separately in DESDEO\n",
+    "    file = \"pymoo_simulator.py\"\n",
+    "    if server:\n",
+    "        file = r\"http://localhost:8000/evaluate\"\n",
+    "    variables = [\n",
+    "        Variable(name=f\"x_{i+1}\", symbol=f\"x_{i+1}\", variable_type=\"real\", lowerbound=0, upperbound=0)\n",
+    "        for i in range(n_vars)\n",
+    "    ]\n",
+    "\n",
+    "    # define all objectives for DESDEO based on the number of objective funcitions\n",
+    "    objectives = [\n",
+    "        Objective(\n",
+    "            name=f\"f_{i+1}\",\n",
+    "            symbol=f\"f_{i+1}\",\n",
+    "            simulator_path=Path(f\"pymoo_simulator.py\"),  # simulator file\n",
+    "            objective_type=\"simulator\",\n",
+    "        )\n",
+    "        for i in range(n_objs)\n",
+    "    ]\n",
+    "\n",
+    "    return Problem(\n",
+    "        name=\"Simulator problem\",\n",
+    "        description=\"\",\n",
+    "        variables=variables,\n",
+    "        objectives=objectives,\n",
+    "        simulators=[\n",
+    "            Simulator(\n",
+    "                name=\"s_1\",\n",
+    "                symbol=\"s_1\",\n",
+    "                file=Path(file),\n",
+    "                parameter_options={\n",
+    "                    \"name\": problem_name,\n",
+    "                    \"n_vars\": n_vars,\n",
+    "                    \"n_objs\": n_objs,\n",
+    "                },\n",
+    "            )\n",
+    "        ],\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fdcb7d80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Problem details\n",
+    "problem_name = \"dtlz2\"\n",
+    "n_vars = 10\n",
+    "n_objs = 3\n",
+    "\n",
+    "pymoo_native = get_problem(problem_name, n_var=n_vars, n_obj=n_objs)\n",
+    "\n",
+    "desdeo_polars = testproblems.dtlz2(n_vars, n_objs)\n",
+    "\n",
+    "simulator_script = simulator_problem(problem_name, n_vars, n_objs, False)\n",
+    "\n",
+    "simulator_server = simulator_problem(problem_name, n_vars, n_objs, True)\n",
+    "\n",
+    "evaluator_polars = Evaluator(\n",
+    "    problem=desdeo_polars,\n",
+    ")\n",
+    "evaluator_script = Evaluator(\n",
+    "    problem=simulator_script,\n",
+    ")\n",
+    "evaluator_server = Evaluator(\n",
+    "    problem=simulator_server,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0f226a1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inds = np.random.uniform(low=0, high=1, size=(1000, n_vars))\n",
+    "inds = pl.DataFrame(inds, schema=[f\"x_{i+1}\" for i in range(n_vars)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8925d9d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import timeit  # prolly not the best way to time things. but eh.\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "times = {\n",
+    "    \"pymoo_native\": timeit.timeit(\n",
+    "        \"pymoo_native.evaluate(inds.to_numpy())\",\n",
+    "        globals=globals(),\n",
+    "        number=100,\n",
+    "    ),\n",
+    "    \"desdeo_polars\": timeit.timeit(\n",
+    "        \"evaluator_polars.evaluate(xs=inds)\",\n",
+    "        globals=globals(),\n",
+    "        number=100,\n",
+    "    ),\n",
+    "    \"simulator_server\": timeit.timeit(\n",
+    "        \"evaluator_server.evaluate(xs=inds.to_dict(as_series=False))\",\n",
+    "        globals=globals(),\n",
+    "        number=100,\n",
+    "    ),\n",
+    "    \"simulator_script\": timeit.timeit(\n",
+    "        \"evaluator_script.evaluate(xs=inds.to_dict(as_series=False))\",\n",
+    "        globals=globals(),\n",
+    "        number=100,\n",
+    "    ),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fd7edcde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normalize the times by pymoo_native\n",
+    "div = times[\"pymoo_native\"]\n",
+    "for key in times:\n",
+    "    times[key] /= div\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d1a97d83",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnYAAAHWCAYAAAD6oMSKAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAVr1JREFUeJzt3QmcjeX///HLEpKlUPalhBp7tggREkpCKYoobUiUIt+IhFKSKKVQIsrWogglouxLqCzZsiu7orj/j/f1+9/ncebMjMaYmTPnOq/n43GYc8+ZM/ecc537/tzX9bk+VzrP8zwDAACAiJc+3DsAAACA5EFgBwAA4AgCOwAAAEcQ2AEAADiCwA4AAMARBHYAAACOILADAABwBIEdAACAIwjsAAAAHEFgBySjdOnSmeeffz4sv3v+/Pn29+v/tCqcr09S/fvvv+bpp582hQsXNunTpzfNmjUzaU2xYsXM/fffH2vbpk2bzM0332xy5sxpX/cZM2bY7cuWLTM1atQwl1xyid2+evXqMO21O/zP3pQpU1L8d+l91vsNJITADs4ZN26cPcgmdPvxxx9NJHvzzTft3xgJr7V/i+QT0ZgxY8yQIUNMy5Ytzfvvv2+6deuWor+vTp06gddNgWSOHDlMqVKlzH333WfmzJmT6Odp166d+emnn8yLL75oxo8fbypXrmz++ecfc+edd5o///zTvPbaa3Z70aJFTVp08uRJexGQ2AsVP7jS7cMPP4z3MTfccIP9fpkyZZK0TxMnTjTDhg1L0s8CqSVjqv0mIJX179/fXHnllXG2X3311SbSA7s8efLE6aGpXbu2+euvv0ymTJlSbV/0OxUcBHvwwQdN1apVzUMPPRTYli1bNvu/9i9jxsg67HzzzTemYMGCNhBKLYUKFTKDBg2yX584ccJs3rzZTJs2zQYsd911l/3/oosuCjz+119/tUGgT6/zDz/8YHr37m06d+4c2P7LL7+Y7du3m9GjR9v3KS1TYNevX79AsJtYWbJksQHYvffeG2v7tm3bzOLFi+33k0rPu27dOvPEE08k+TmAlBZZR1jgPDRq1Mj2UkQLndgv5KSVFFdddZW9BXvkkUfsttATq6T2/iWH/fv3m0svvTTZnu/s2bPm9OnT53wtNHwa+voNHjzYPP744zawVw/oSy+9FPhe5syZYz32wIED9v/Q/dbfEt/2C6HAU8O6aUXjxo3NZ599Zg4ePGgvgIKDsrx585oSJUqYQ4cOhXUfgZTEUCyikoakcuXKZdq3bx/ne0ePHrUn3aeeesre10m4T58+plKlSvaEq5NYrVq1zLfffpvkfBgNMWlIKNjYsWPNTTfdZK644gp7oo6JiTFvvfVWrMfoudavX2++++67wLCT35uRUI7dJ598Yvf94osvtic6BQy7du2Ks5/qVdN25ZDp68svv9y+BmfOnDEplWPnvw4bN260+6XXV7/3ueeeM57nmZ07d5rbb7/dDkfmy5fPvPrqq3Ge89SpU6Zv3762J1avm3LhlBOn7cE0jFmzZk0b1Ojv0/Dms88+m+C+qodH+6b3Wa+5/3r7r68CmieffNL+Pv1ePd8rr7xi9zv0b1av2YQJE0zp0qXtY2fNmnXer12GDBnM8OHDbbsYMWKEOXLkSLw5dnpN/eHVHj16BIbC9f0bb7zRbtdwbHDb8XvzNNysz4Xavy6KFCDFN/Su9vfYY4/ZtqreRd9XX31lPxv6jGTPnt00adLEvnbn29b02mubqNfOf+0Tk5+p9qLXWO0+mAI79XbqdYyPekH9z4leg7vvvtu2P59eq5kzZ9oez4RSDBS0a+hbr4lew3r16tne1lCJ+UyK8iI1bKzn0v/Tp0+Pd98nTZpkn0+vuT4rZcuWNa+//vp/vlZwEz12cJZOfLpqD6aDce7cue0w1h133GGHt95+++1Yw5c6mCoo0IHdD/Teffddc88995iOHTuaY8eOmffee880bNjQLF261FSoUCFZ9ldBnE78TZs2tcOVn3/+uT156mTRqVMn+xjl93Tp0sWeDDXMJuqFSIhOxApeq1SpYof29u3bZw/4ixYtMqtWrYrVc6OTqv6matWq2QBl7ty5NpAqXry4efTRR01KatWqlbn22mttr5ROngMGDLAnV703CnbVO6XASCd//S0aAha9Nnq9vv/+ezv0q+dQXpmGTRUs+hMGFFzceuutply5cnaIXid+nXD1OiREgYWGmXWiPn78eGBoVL9DwZt+r4K+Bx54wLaB2bNn20BKJ+jQYVsN53788cc2wNOJPKk5hwpK1A4V+OpvVuAUqnnz5vZ9VS6gHqseLLUXtRMNKQ8cOND2/Ol19NuOXh/ln+n7PXv2tIGZ9leB19SpU+1nJZjapV4fXfAowBW9VsrrUxvS+6WhVLVpBdNqa8F/83+1NT23flZf63frbxK9f/8la9asNrj76KOPAu12zZo19m/U53jt2rVxfkbvsV5TBX4aolaP5xtvvGHbmf850edNx5Tff/898P76KQY+tV/1nKud6rEvv/yyadOmjVmyZMl5fya//vpr06JFCxvI63F//PGH/bngQNq/YNH7rCDS78X9+eef7fN17dr1P18vOMgDHDN27Fh1mcR7y5w5c+Bxs2fPtts+//zzWD/fuHFj76qrrgrc//fff71Tp07FesyhQ4e8vHnzeh06dIi1Xc/Xt2/fwP127dp5RYsWjbOPekzox+/kyZNxHtewYcNY+yKlS5f2brzxxjiP/fbbb+1z6n85ffq0d8UVV3hlypTx/vrrr8DjvvjiC/u4Pn36xNpPbevfv3+s56xYsaJXqVIl73xccskl9vniE/r6+K/DQw89FOv1LlSokJcuXTpv8ODBsV7ziy++ONZzjx8/3kufPr23cOHCWL9n1KhR9nkXLVpk77/22mv2/oEDB7zzpddar3mwGTNm2OcbMGBArO0tW7a0+7158+ZYf7P2cf369Un+fcGmT59un/P1118PbFMbC35dtm7dah8zZMiQeNvIJ598Emt7vXr1vLJly3p///13YNvZs2e9GjVqeCVKlIjz2apZs6Z9n3zHjh3zLr30Uq9jx46xnnfv3r1ezpw5Y21PbFvTexXaXs4l+G9TG9f7sGPHDvu9Hj16BD5Hoa/vtm3bvAwZMngvvvhirOf76aefvIwZM8ba3qRJk3g/z/7vvvbaa2MdK/Qeabue63w/kxUqVPDy58/vHT58OLDt66+/to8L3oeuXbt6OXLkiPV+ILoxFAtnjRw50l7NBt80VORTT5B6TyZPnhzYptwbPU49SMG9JH6PnnqINKNQJTA0VLVy5cpk218Ny4T2Nmro7Lfffos17JZYy5cvtzlV6l0JzudSL88111xje8ZCKT8umIbV9PtTWnAiv15vvbaKidQb5lNPhoY7g/dHQ1rqQdPfo9fLv+m9FX+43O8F+fTTT+17eKG+/PJLu5/q+QqmoVntd3A7E72P6nlJDn4vkXqOk4Pas3oU1Vul5/RfQ/UQqVdNZVNChwnVcx08pKnPzOHDh23PUfD7oMeoVy6+tIWUbGsq86IeXw1R6v3Q/9q3+KjXXm1Cf3/wvmvoX/l4iUm58KlHLbj3X3+T+H9XYj+Te/bssWVo1AOq9ARfgwYN4rQjtW31mp7PjGm4jaFYOEszM881eULDnRrqUO6Nhl41PKeDvPLvggM7UZkLDRUpD0nf98U36zapNHSiXDHNZtQwVjAFdsEH+MRQLpAoGAqlk4iG8oLpROPnNfkuu+yyVEk0L1KkSKz7+lu1P8HJ7/52BRw+BR0adgrd79DJAno/NQynAFJDjRq20vCecsqCZ5Oez2tboEABm9MUTEGm//1gydlONCwsob87qTQkreBHQ5G6JfQ6apg2ob9H74P4AXUo5X2lZltTqoXyCPXZ1nFAuXKtW7eO97Had/39CuISeq6ktmP9TeL/XYn9TPqPi2+f9LPBF5QKEjVsrslieo8U1CpIveWWWxK933ALgR2imvLolMelHhblE+kAqQNs+fLlYyVVK+Fb31cOlRLG1ROhvJctW7ac8/lDJ0j4Qick6HkUbOh3Dx061Cbk68pfPUPK50mOXqb/klBSeWqI73cntD/BkxP0uihRXK9ZfPQ6+r2hCxYssL0v6hXR5AX11CoQUS5TSv/twb2xF0rlNpKzbI/ftpQXph66+IT+rtC/x38O5dmppytUaImb1GhrCuRGjRplJ1zo85xQj6n2XZ9THQPi26/QPLpzSUybTW46Hql3Tzme+ht000Sstm3b2gtSRB8CO0Q1JUfnz5/fnuSV5K0hKX9Sgk/V5FW+Q715wYGaetf+i67YNUQVKrRHRxMl1GuoWYjBV/3xDQMlFCyG8mdGqsZZaE+KtqXVwrTnQ8n2SoxXUPxfr4t65vQ43RQIahKB3mu9xvXr1z+v36vXTgn/GroM7jlTj67//ZSgCwL1QmmCgNprcvDL1ahn6nxfh+D3wQ8ykvocSW3nCdHro8+SZjEHl4aJb98VeKkXsmTJkim6T4n9TPr/+z2hoY8LpYvA2267zd4UqKoXTxes6oGN9LqdOH/k2CGq6WSv4TgFVuptUO5c6DCsfxUefNWtWW4aMv0vOmloGDV4Jp7yZ0LLFsT3O/RzuvIOpRmL8QWLoTQMrROtei2CS3/oil7Dl/HNqIw0GnJS/pcK7oZSkV5/xqbyyEL5s5lDy6IkhmaaKshS2ZFg6l3VyV/DYslNv085fXrv9H/o8GZSqY2olIcCAbXNUH5NvHNRT5/2R8FycKrC+TxHKAWvkpi2Hh+9DyoPowswrdqREA3J6/OnsiqhPWu6Hzz0r89eUvJdz/czqYtNtU/1uAX/PuXRbdiwIdZzBu+ff0zzZw8npW0j8tFjB2fpYOn3oATTOpnBRXUVyKm0gU4AGtbz86R8KpOh3jqVXdCBd+vWrfbArKEdP9/pXEO9zzzzjP1ZnYz9EhDqGQjOk1FejH/V/fDDD9vnVbCik0DoyVb1qvQcKgmiq3E9Jr7cJvXAqKdCCd1K3lfyuF9aQaUnUnpprNSgE7aGz5WIr543lexQAKT3Xds1PKWTqUqcaChW7596Q5QzpkK/Kh2RlJ4vvU9169a1PX6quaahPg3panKGViXwe7CSSidzf1kstRl/5QkN2atNvfDCCya5JxrpdVD718QIfT7UVnTxovIe6hU9FwV1apN6P6677jq7j8qh27Fjhx361vsSGgT/Fw336jOm3nR9XjQZQrXczmc5MJU90e1c9F7ps9SrVy/7XirlQr2w+pzrAkxldPyalvrsaX+6d+9uy5VomFZtIbHO5zOpVA+1V70vHTp0sBcnOk6pJFLwcUd5o/qejgFqzxoN0OMUGIYeyxAlwj0tF0jNcie66fvBVNahcOHC8Zav8L8/cOBAW2JA5VJUlkHlCeIrZRJfeQaVKFB5g0yZMnmlSpXyPvzww3jLnXz22WdeuXLlvCxZsnjFihXzXnrpJW/MmDH2cSpfEVxCQmUXsmfPbr/nlz4JLXfimzx5st1n7XuuXLm8Nm3aeL///nusx+hvUZmSUPHtZ0qUOwktQ5LQ/sRXCkQlJPRaabv+xssuu8yWzejXr5935MgR+5h58+Z5t99+u1egQAH7Puj/e+65x9u4cWOSy4+oxEe3bt3sc1100UW2LIjKi6i9hP7NnTp1+s/fE/z7gttrtmzZ7HPfe++9ti3F50LLnciWLVu8tm3bevny5bN/T8GCBb1bb73VmzJlSpzP1rJly+LdDz2/SvSoxInacfHixb3777/fW758eZLa2uLFi+17qffsv0qfnOtvS8z7OXXqVFvGRfum2zXXXGPft19//TXwmOPHj3utW7e2pV2Cy44k9Lv99yH0mJOYz6S/TyqhosfFxMR406ZNi3Pc0ftz88032zIqep2KFCniPfzww96ePXvO+TrAXen0T7iDSwAAAFw4cuwAAAAcQWAHAADgCAI7AAAARxDYAQAAOILADgAAwBEEdgAAAI6I+gLFWn5l9+7dtiDlhS4XAwAAkNxUmU5LGBYoUMCuLnIuUR/YKajzFwoHAABIq3bu3GlXGDmXqA/s/AW89WIl19qLAAAAyeXo0aO2E8qPWc4l6gM7f/hVQR2BHQAASKsSkzLG5AkAAABHENgBAAA4gsAOAADAEQR2AAAAjiCwAwAAcASBHQAAgCMI7AAAABxBYAcAAOAIAjsAAABHENgBAAA4gsAOAADAEQR2AAAAjsgY7h0AAABxFes5M9y7gETaNriJSSvosQMAAHAEgR0AAIAjCOwAAAAcQWAHAADgiIgP7A4fPmwqV65sKlSoYMqUKWNGjx4d7l0CAAAIi4ifFZs9e3azYMECkzVrVnPixAkb3DVv3tzkzp073LsGAACQqiK+xy5Dhgw2qJNTp04Zz/PsDQAAINqEPbBTb9ttt91mChQoYNKlS2dmzJgR5zEjR440xYoVM1myZDHVqlUzS5cujTMcW758eVOoUCHTo0cPkydPnlT8CwAAANKGsAd2Gj5VUKbgLT6TJ0823bt3N3379jUrV660j23YsKHZv39/4DGXXnqpWbNmjdm6dauZOHGi2bdvXyr+BQAAAGlD2AO7Ro0amQEDBpg77rgj3u8PHTrUdOzY0bRv397ExMSYUaNG2aHXMWPGxHls3rx5beC3cOHCBH+fhmuPHj0a6wYAAOCCsAd253L69GmzYsUKU79+/cC29OnT2/s//PCDva/euWPHjtmvjxw5Yod2S5UqleBzDho0yOTMmTNwK1y4cCr8JQAAAFEe2B08eNCcOXPG9sQF0/29e/far7dv325q1aple+r0f5cuXUzZsmUTfM5evXrZANC/7dy5M8X/DgAAgNQQ8eVOqlatalavXp3ox2fOnNneAAAAXJOme+w0u1XlTEInQ+h+vnz5wrZfAAAAaVGaDuwyZcpkKlWqZObNmxfYdvbsWXu/evXqYd03AACAtCbsQ7HHjx83mzdvDtxXyRINrebKlcsUKVLEljpp166dXTZMw67Dhg2zJVI0S/ZCqLyKbsrhAwAAcEE6L8zLNMyfP9/UrVs3znYFc+PGjbNfjxgxwgwZMsROmNCasMOHD7eFipODyp1odqwmUuTIkSNZnhMAgAtVrOfMcO8CEmnb4CYp+vznE6uEPbALNwI7AEBaRGAXObalocAuTefYAQAAIPGiNrBTfp1WsqhSpUq4dwUAACBZRG1g16lTJ7NhwwazbNmycO8KAABAsojawA4AAMA1BHYAAACOILADAABwBIEdAACAI6I2sGNWLAAAcE3UBnbMigUAAK6J2sAOAADANQR2AAAAjiCwAwAAcASBHQAAgCOiNrBjViwAAHBN1AZ2zIoFAACuidrADgAAwDUEdgAAAI4gsAMAAHAEgR0AAIAjCOwAAAAcQWAHAADgiKgN7KhjBwAAXBO1gR117AAAgGuiNrADAABwDYEdAACAIwjsAAAAHEFgBwAA4AgCOwAAAEcQ2AEAADiCwA4AAMARURvYUaAYAAC4JmoDOwoUAwAA10RtYAcAAOAaAjsAAABHENgBAAA4gsAOAADAEQR2AAAAjiCwAwAAcASBHQAAgCMI7AAAABxBYAcAAOAIAjsAAABHRG1gx1qxAADANVEb2LFWLAAAcE3UBnYAAACuIbADAABwBIEdAACAIwjsAAAAHEFgBwAA4AgCOwAAAEcQ2AEAADiCwA4AAMARBHYAAACOILADAABwBIEdAACAIwjsAAAAHEFgBwAA4AgCOwAAAEcQ2AEAADgiagO7kSNHmpiYGFOlSpVw7woAAECyiNrArlOnTmbDhg1m2bJl4d4VAACAZBG1gR0AAIBrCOwAAAAcQWAHAADgCAI7AAAARxDYAQAAOILADgAAwBEEdgAAAI4gsAMAAHAEgR0AAIAjCOwAAAAcQWAHAADgCAI7AAAARxDYAQAAOILADgAAwBEEdgAAAI4gsAMAAHAEgR0AAIAjMiblh7Zu3WoWLlxotm/fbk6ePGkuv/xyU7FiRVO9enWTJUuW5N9LAAAAJG9gN2HCBPP666+b5cuXm7x585oCBQqYiy++2Pz5559my5YtNqhr06aNeeaZZ0zRokXP56kBAACQWoGdeuQyZcpk7r//fjN16lRTuHDhWN8/deqU+eGHH8ykSZNM5cqVzZtvvmnuvPPOC90/AAAAJHeO3eDBg82SJUvMY489Fieok8yZM5s6deqYUaNGmV9++cVcddVVJjXs3LnT/t6YmBhTrlw588knn6TK7wUAAIjYHruGDRsm+klz585tb6khY8aMZtiwYaZChQpm7969plKlSqZx48bmkksuSZXfDwAAENGzYleuXGl++umnwP1PP/3UNGvWzDz77LPm9OnTJjXlz5/fBnWSL18+kydPHpvzBwAAEG2SFNg9/PDDZuPGjfbr3377zdx9990ma9asdhj06aefPq/nWrBggbntttvsRIx06dKZGTNmxHnMyJEjTbFixezkjGrVqpmlS5fG+1wrVqwwZ86ciXeoGAAAwHVJCuwU1Pm9ZArmateubSZOnGjGjRtnJ1acjxMnTpjy5cvb4C0+kydPNt27dzd9+/a1PYV6rIaF9+/fH+tx6qVr27ateeedd5LyJwEAAERnHTvP88zZs2ft13PnzjW33nqr/Vo9ZQcPHjyv52rUqJG9JWTo0KGmY8eOpn379va+JmfMnDnTjBkzxvTs2TMwI1dDwbpfo0aNc/4+PVY339GjR89rfwEAAJwK7FTOZMCAAaZ+/frmu+++M2+99VagcLHq2yUX5etpeLVXr16BbenTp7e/V6VV/CBTJVhuuukmc9999/3ncw4aNMj069cv2fYRAJJLsZ4zw70LSIRtg5uEexeA5B2K1SxUDYt27tzZ9O7d21x99dV2+5QpU/6zx+x8qPdPOXOhwaLuawasLFq0yA7XKjdPw8O6BU/sCKUg8ciRI4GbyqUAAABEbY+d6sXFFzwNGTLEZMiQwaSmmjVrBoaFE0P19nQDAABwTZICu4Qk9zqxKl2iQHHfvn2xtuu+SpsAAAAgCYHdZZddZsuRJEZy1ZHTEmYqODxv3jw7OULUO6f7GgYGAABAEgI75dX5/vjjDzt5QmVHqlevbrdpMsPs2bPNc889Z87H8ePHzebNmwP3NQFj9erVJleuXKZIkSK21Em7du3shI2qVava/VCJFH+WbFKpvIpuyuEDAABwQTpP00rPU4sWLUzdunXj9JqNGDHClj+Jr8hwQubPn2+fK5SCOdXF859X+XuaMKHJEcOHD7eFipODyp3kzJnTTqTIkSNHsjwnACQFs2IjQ2rNiqU9RI5tKdwmzidWSVJgly1bNtur5s+G9annTYGXeuEiBYEdgLSCE3lkILBDWg7sklTuJHfu3HZ92FDapu8BAAAgQmbFqsDvgw8+aIdR/SHRJUuWmFmzZpnRo0ebSECOHQAAcE2Seuy00oMKA6s7cNq0afamr7///nv7vUjQqVMns2HDBrNs2bJw7woAAEB469ipp27ChAnJsxcAAAAIX2CnenKaLLF///44Kz/Url37wvcMAAAAKR/Y/fjjj6Z169Zm+/btJnRSrYoYk7cGAAAQIYHdI488YgsGz5w50+TPnz/RK1IAAAAgjQV2mzZtMlOmTIlTxy6SMCsWAAC4Jn1SJ04ELwMWiZgVCwAAXJOkHrsuXbqYJ5980i7xVbZsWXPRRRfF+n65cuWSa/8AAACQkoGd1oqVDh06BLYpz04TKZg8AQAAEEGB3datW5N/TwAAAJD6gV3RokUv7LcCAAAg7RQo3rJlixk2bJj5+eef7f2YmBjTtWtXU7x4cRMJmBULAABck6RZsbNnz7aB3NKlS+1ECd2WLFliSpcubebMmWMiAbNiAQCAa5LUY9ezZ0/TrVs3M3jw4Djbn3nmGdOgQYPk2j8AAACkZI+dhl8feOCBONs1S1a9YAAAAIiQwO7yyy83q1evjrNd26644ork2C8AAACkxlBsx44dzUMPPWR+++03U6NGDbtt0aJF5qWXXjLdu3dPylMCAAAgHIHdc889Z7Jnz25effVV06tXL7utQIEC5vnnnzePP/74he4TAAAAUiuw0+oSmjyh27Fjx+w2BXoAAACIsBw7rTyxadOmQEDnB3Xatm3bNhMJVMNOJVuqVKkS7l0BAAAIX2B3//33m8WLF8fZrlp2+l4koI4dAABwTZICu1WrVpkbbrghzvbrr78+3tmyAAAASKOBnXLs/Ny6YEeOHGGJLgAAgEgK7GrXrm0GDRoUK4jT19pWs2bN5Nw/AAAApOSsWNWrU3BXqlQpU6tWLbtt4cKF5ujRo+abb75JylMCAAAgHD12mk26du1ac9ddd5n9+/fbYdm2bduaX375xZQpU+ZC9wkAAACp1WPnFyQeOHBgUn8cAAAAaaHHzh96vffee+2SYrt27bLbxo8fb77//vvk3D8AAACkZGA3depU07BhQ3PxxReblStXmlOnTgVmxUZKLx4FigEAgGuSFNgNGDDAjBo1yowePdpcdNFFge2qbadALxJQoBgAALgmSYHdr7/+amfFhsqZM6c5fPhwcuwXAAAAUiOwy5cvn9m8eXOc7cqvu+qqq5LylAAAAAhHYNexY0fTtWtXuzasVqHYvXu3mTBhgnnqqafMo48+eqH7BAAAgNQqd9KzZ09z9uxZU69ePXPy5Ek7LJs5c2Yb2HXp0iUpTwkAAIBwBHbqpevdu7fp0aOHHZI9fvy4nWGaLVu2C90fAAAApHYdO8mUKZMN6K655hozd+5c8/PPP1/I0wEAACC1AzstJTZixAj79V9//WVrwWlbuXLlbI07AAAAREhgt2DBAlOrVi379fTp022+ncqcDB8+3Na4AwAAQIQEdlphIleuXPbrWbNmmRYtWpisWbOaJk2amE2bNiX3PgIAACClArvChQubH374wZw4ccIGdjfffLPdfujQIZMlS5akPCUAAADCEdg98cQTpk2bNqZQoUKmQIECpk6dOoEh2rJly5pIwFqxAADANUkqd/LYY4+ZatWqmR07dpgGDRqY9On/Lz7UqhORkmOntWJ1O3r0qF0KDQAAICoDO6lUqZK9BVOOHQAAANL4UOzgwYNtaZPE0FJjM2fOvJD9AgAAQEoFdhs2bDBFihSxw7BfffWVOXDgQOB7//77r1m7dq158803TY0aNUyrVq1M9uzZz3dfAAAAkBpDsR988IFZs2aNLUzcunVrm5uWIUMGu0as1ouVihUrmgcffNDcf//9zI4FAABIyzl25cuXN6NHjzZvv/227aHbvn27HZ7NkyePqVChgv0fAAAAETR5QrNgFcjpBgAAgAiuYwcAAIC0h8AOAADAEQR2AAAAjiCwAwAAcMQFBXabN282s2fPDhQu9jwvufYLAAAAqRHY/fHHH6Z+/fqmZMmSpnHjxmbPnj12+wMPPGCefPLJpDwlAAAAwhHYdevWzWTMmNHs2LHDZM2aNbBdK07MmjXrQvcJAAAAqVXH7uuvv7ZDsIUKFYq1vUSJErZoMQAAACKkx+7EiROxeup8f/75p11iDAAAABES2NWqVcuuHetLly6dOXv2rHn55ZdN3bp1TSQYOXKkiYmJMVWqVAn3rgAAAIRvKFYBXL169czy5cvN6dOnzdNPP23Wr19ve+wWLVpkIkGnTp3s7ejRoyZnzpzh3h0AAIDw9NiVKVPGbNy40dSsWdPcfvvtdmi2efPmZtWqVaZ48eIXvlcAAABInR47US9X7969k/rjAAAASCuB3d9//23Wrl1r9u/fb/PrgjVt2jQ59g0AAAApHdipVl3btm3NwYMH43xPEynOnDmTlKcFAABAaufYdenSxdx55512xQn11gXfCOoAAAAiKLDbt2+f6d69u8mbN2/y7xEAAABSL7Br2bKlmT9/ftJ+IwAAANJOjt2IESPsUOzChQtN2bJlzUUXXRTr+48//nhy7R8AAABSMrD76KOP7HqxWbJksT13mjDh09cEdgAAABES2Kl+Xb9+/UzPnj1N+vRJGs0FAABAMktSVKZlxFq1akVQBwAAkIYkKTJr166dmTx5cvLvDQAAAFJ3KFa16l5++WUze/ZsU65cuTiTJ4YOHZr0PQIAAEDqBXY//fSTqVixov163bp1sb4XPJECAAAAaTyw+/bbb5N/TwAAAHBBmP0AAAAQbT12zZs3N+PGjTM5cuSwX5/LtGnTkmPfAAAAkBKBXc6cOQP5c/oaAAAAERrYjR071vTv39889dRT9msAAABEcI6dVps4fvx4yu0NAAAAUiew8zzPpEV33HGHueyyy0zLli3DvSsAAACRMys2Ldap69q1q/nggw/CvRsAAACRVceuZMmS/xnc/fnnnyY11alTx8yfPz9VfycAAEDEB3bKs0vOWbELFiwwQ4YMMStWrDB79uwx06dPN82aNYv1mJEjR9rH7N2715QvX9688cYbpmrVqsm2DwAAAFEZ2N19993miiuuSLYdOHHihA3WOnToEG99vMmTJ5vu3bubUaNGmWrVqplhw4aZhg0bml9//TVZ9wMAACCqAruUyK9r1KiRvSVk6NChpmPHjqZ9+/b2vgK8mTNnmjFjxpiePXue9+87deqUvfmOHj2axD0HAABIW9L0rNjTp0/bIdr69esHtqVPn97e/+GHH5L0nIMGDbJDyf6tcOHCybjHAAAAERLYnT17NlWHPw8ePGjOnDlj8ubNG2u77ivfzqdA78477zRffvmlKVSo0DmDvl69epkjR44Ebjt37kzRvwEAACDN5tilRXPnzk30YzNnzmxvAAAAJtrr2KWmPHnymAwZMph9+/bF2q77+fLlC9t+AQAApEVpOrDLlCmTqVSpkpk3b16s4WDdr169elj3DQAAIK0J+1Cs1p7dvHlz4P7WrVvN6tWrTa5cuUyRIkVsqZN27dqZypUr29p1KneiEin+LNmkUm083ZTDBwAA4IKwB3bLly83devWDdxXICcK5saNG2datWplDhw4YPr06WMnTFSoUMHMmjUrzoSK89WpUyd7U7mT5Cy4DCRWsZ4zw70LSIRtg5uEexcAIHICOy0H9l9lVDp37mxvAAAAiNAcOwAAACRe1AZ2yq+LiYkxVapUCfeuAAAAJIuoDeyUX7dhwwazbNmycO8KAABAsojawA4AAMA1BHYAAACOILADAABwBIEdAACAI6I2sGNWLAAAcE3UBnbMigUAAK6J2sAOAADANQR2AAAAjiCwAwAAcASBHQAAgCOiNrBjViwAAHBN1AZ2zIoFAACuidrADgAAwDUEdgAAAI4gsAMAAHAEgR0AAIAjCOwAAAAcQWAHAADgiKgN7KhjBwAAXBO1gR117AAAgGuiNrADAABwDYEdAACAIwjsAAAAHEFgBwAA4AgCOwAAAEcQ2AEAADiCwA4AAMARURvYUaAYAAC4JmoDOwoUAwAA10RtYAcAAOAaAjsAAABHENgBAAA4gsAOAADAEQR2AAAAjiCwAwAAcASBHQAAgCMI7AAAABxBYAcAAOAIAjsAAABHRG1gx1qxAADANVEb2LFWLAAAcE3UBnYAAACuIbADAABwBIEdAACAIwjsAAAAHEFgBwAA4AgCOwAAAEcQ2AEAADiCwA4AAMARBHYAAACOILADAABwBIEdAACAIwjsAAAAHEFgBwAA4AgCOwAAAEcQ2AEAADgiagO7kSNHmpiYGFOlSpVw7woAAECyiNrArlOnTmbDhg1m2bJl4d4VAACAZBG1gR0AAIBrCOwAAAAcQWAHAADgCAI7AAAARxDYAQAAOILADgAAwBEEdgAAAI4gsAMAAHAEgR0AAIAjCOwAAAAcQWAHAADgCAI7AAAARxDYAQAAOILADgAAwBEEdgAAAI4gsAMAAHAEgR0AAIAjCOwAAAAcQWAHAADgCAI7AAAARzgR2H3xxRemVKlSpkSJEubdd98N9+4AAACERUYT4f7991/TvXt38+2335qcOXOaSpUqmTvuuMPkzp073LsGAACQqiK+x27p0qWmdOnSpmDBgiZbtmymUaNG5uuvvw73bgEAAERfYLdgwQJz2223mQIFCph06dKZGTNmxHnMyJEjTbFixUyWLFlMtWrVbDDn2717tw3qfPp6165dqbb/AAAAaUXYA7sTJ06Y8uXL2+AtPpMnT7ZDrX379jUrV660j23YsKHZv39/qu8rAABAWhb2wE5DpwMGDLB5cfEZOnSo6dixo2nfvr2JiYkxo0aNMlmzZjVjxoyx31dPX3APnb7WtoScOnXKHD16NNYNAADABWl68sTp06fNihUrTK9evQLb0qdPb+rXr29++OEHe79q1apm3bp1NqDT5ImvvvrKPPfccwk+56BBg0y/fv1MaivWc2aq/06cv22Dm4R7FwAAiNweu3M5ePCgOXPmjMmbN2+s7bq/d+9e+3XGjBnNq6++aurWrWsqVKhgnnzyyXPOiFWQeOTIkcBt586dKf53AAAAmGjvsUuspk2b2ltiZM6c2d4AAABck6Z77PLkyWMyZMhg9u3bF2u77ufLly9s+wUAAJAWpenALlOmTLbg8Lx58wLbzp49a+9Xr149rPsGAACQ1oR9KPb48eNm8+bNgftbt241q1evNrly5TJFihSxpU7atWtnKleubCdKDBs2zJZI0SzZC6HyKrophw8AAMAFYQ/sli9fbic++BTIiYK5cePGmVatWpkDBw6YPn362AkTmiAxa9asOBMqzlenTp3sTeVONJsWAAAg0oU9sKtTp47xPO+cj+ncubO9AQAAIEJz7AAAAJB4URvYKb9OK1lUqVIl3LsCAACQLKI2sFN+3YYNG8yyZcvCvSsAAADJImoDOwAAANcQ2AEAADiCwA4AAMARYS93Em5+qRXVs0tJZ0+dTNHnR/JI6XYQjDYRGWgTCFeboD1EjqMp3Cb85/+v8nCSzkvMoxzkrzxx+vRps2XLlnDvDgAAwDnt3LnTFCpU6JyPidrALnjt2d27d5vs2bObdOnShXt3IoauHgoXLmwbWY4cOcK9O0gDaBMIRZtAKNpE0ihUO3bsmClQoIBJn/7cWXRRPxSrF+i/ol8kTB9MPpwIRptAKNoEQtEmzl9ilz9l8gQAAIAjCOwAAAAcQWCHJMmcObPp27ev/R8Q2gRC0SYQijaR8qJ+8gQAAIAr6LEDAABwBIEdAACAIwjsAAAAHEFgBwAA4AgCOwAAEHWrTonmj7o2h5TADgAQNSdy+eOPP8K6Lwivf/75J7As1+HDh51bTpTADoATJ2tx7cobycc/kffs2dMMGzbMHDlyJNy7hDCYPn26+fzzz+3XXbt2NXfccYcN9FwS9WvFInJO4P+18DGit01MmjTJlCtXzsTExIR7t5DGKNj3e2QWLlxoJkyYYKZNm5bodTfhlkmTJtn3v3HjxrY9LFiwwFx00UXGJQR2iKgT+AcffGC2b99ub126dDHFixc32bJlC/cuIgwna79N9OrVy7aLbt26maJFi5pLLrkk3LuHNMQP6t544w1z6NAhc++995oqVaqEe7cQJpMnTzbXXnut+fLLL83LL79sypQpY1xDFwjSPP8E3qNHD/Pss8+aLVu22ByZ6tWrm7Fjx5pTp06FexcRppP1wIEDzbvvvms+++wz07lzZ4I6JHhxOHv2bPP888+bdevWOTf0hsQ5deqUOXHihClSpIipX7++6devn5k6dao5ffp0nFSOSE7rILBDRJgxY4btQtdV1rhx42wvzd9//20KFizImoNRmlP3119/2WGUwYMHm0qVKpn9+/ebOXPmmJYtW5qhQ4ean3/+Oaz7ivAJPSnr4lC5VR06dDDffvut+eabb8K2bwjfMSNTpkz24k9B/ldffWVuueUW2yaUc6fgzr9g1LEkkidUMBSLNJ8XI+qhq1Gjhs2jmjhxonnkkUfMyJEjTfPmzc2xY8dsInShQoXCus9Ivd5bXWW3aNHCDskvXrzYFCtWzIwYMcIekLNmzWqDPbUJXZEjelM3Nm/ebHtpdDJXG1HvroZj27RpYwO9WrVqhXt3kUopG+PHjzcbNmww+fLlM6VKlbJBnToL7r77btOxY0d7PlF7eOyxx0zGjBltHl7E8oAI0K9fP++mm27yvvnmGy9Hjhzem2++Gfje6NGjvS5dungnTpwI6z4i5Zw5cybw9YABA7x06dJ5O3bs8D799FOvQIEC3mWXXeb16tXL+/bbb+1junXr5rVo0SKMe4xwOHv2bODr3r17e5UrV/by5Mnj3XzzzV7nzp0Dj7nzzjvt9oULF4Zxb5FabeHZZ5/1smXL5t1yyy1eyZIlvVKlSnk9evQIfP++++7zcufObbeXK1fOO336tBfJCOyQZg0ZMsR76KGH7NebN2/2ypcvb0/owUHdyZMnvdtuu83r2LFjrA8y3LRs2TJ7kJ47d25g2x9//OFt3bo1VhBYv359r3v37mHaS4Tbiy++aE/UCvR37tzpPfjgg/bYofYj//77rw3utG3NmjXh3l2k4IXgihUrbKeAH8Tv2rXLe+WVV7wiRYp4ffr0CTxu5syZ9kJRbUP++ecfL1IxFIs0SRcdyodQovPWrVtN/vz5TatWrcyZM2fsNg3BaRLFK6+8Ynbt2mW7zTV0GzqEC3coJ0b5MBkyZLDDJ6Ik+Fy5ctnb8ePHzZIlS8xrr71m9u7dax8vtInoooKzGp4fNWqUqVOnjm0Hmgn5zjvvmMqVK9vc3CxZsthtzz33nCldunS4dxnJ5NNPPzVNmzYNDL9qeFX5dKI0HilQoIBp27atTdWYO3euad++vR2mV/kTn84zGo6NVEyeQJqkE7HyHXbs2GE/fMqbevDBB22pAiXMa7r6U089ZR+3fPly+yHUh5ETuLty585tGjVqZA4cOGDfc1H9KT9Rfu3atfZkrvsrV66kTURpkWq1iW3btpm8efOamTNnmrvuusuWtdDxQwnyyrObP3++bRcDBgywFwr//vtv2PYfyaNPnz42bzKYcitVq27ZsmX2+OC7/PLLbY6dtu/evduEUpuIaOHuMgT8ru/4vPDCC7bL3B9qU+6DusiXLl1qu9T9LvdI7jbHuYdSgq1evdq79957vaJFi3qffPJJrO8px/Lnn3+mTUQpDaXpOKH0jKZNm3p33XWXzb0MTt3YsmWL16RJE2/SpElh3Vckv8OHDwc+8ytWrAicVzS8mjdvXq9t27be2rVrA4/ftm2bzbfz83JdQmCHsGnTpo139OjRWHkxynkI/qCtX7/eq169ujd+/Hh7309qDc6nSygIQGQKfj+XLFnizZ8/3/7vW758udehQwfv2muv9aZMmfKfzwG36VigPLmcOXPayVWioF/5c8q//euvv+y2Q4cOeY0bN/ZuvPHGc15MIvIET3b47LPPvBIlSngjRowIvM8K5AsWLGiD+rFjx3pz5syxX5cpU8bJthC5g8iIaBoqUX5UcA06DZupvpRWEbj55pttSZOKFSuaqlWrmpdeeskOw/pLvwQPr7HUmJvlCXr37m2HVlSe4sorrzRly5Y1b7/9tq1Z9+ijj9o2oIKzqmenthGMNhE91A6UP9WwYUNb31J16lTLUMPyaifKudJQq27Kq9IwvobadLyJ+CE3WP554YsvvrDpGh9++KH5+OOP7XHgoYcesvnZ+lpFzFULVcPzWqVGOXlOtoVwR5bAW2+9ZWc2ioZSvvjiC6906dJe1apVvVatWnnfffedLWmhxyE6qPf2iiuusDPZjhw54j355JO2B+buu++O1XPXvHlzr3Xr1mHdV6Su0Nnvp06dsv/rOKFjho4fPvXgPf/8894TTzzhjRo1KjBUxzC9u2WQ9u7d6x08eNCeO2644QY7FO/3yqk3L3/+/LbUyYYNG+I8hysI7BDWA7MCOuXQqetcQyW+Y8eO2WE21Z+69NJL7QdWJ3e458svv4w1JK/hd5UnmDVrlr2v/1WDSiVtlCujIXxfcE4douvYoXbx999/B+7r65o1a3otW7Y853O4OPQW7eIrg3QwKLhTp4D/vk+cONErVKiQ16lTp1g5dy4hsEOqCq439tFHH9lEZ105ValSxfbSBQd3vo8//tjm3nGV7R7lvihoHzlypHf8+PHAdvWu7N+/3/bYqbf27bffttvbtWtnH9+gQYNYz0Nw577g91i9ctdff71XuHBh78MPP/R++uknu/3HH3+0J20dM3zUt3R/0ky+fPlsDp0fqJ3+/zl3Cu7Uy1+rVi1bF9VvQ+o0uPjii21nQaQXI44PiShINSpTolwo5UF069bNtG7d2i4VptIl77//vq1bV7NmTVuHSvyFuu+88067NJTKV1CWwC3Kfenbt6954okn7BrAyoGShx9+2JYk+Oyzz2zOjOpOydVXX21uvfVWW8oiuMwFOXXRk3upMkcqU6Jc3GbNmpnhw4fbpQVfffVV+5jatWubVatWBX6Ocjdul7fREmEqXRJaBumff/6xJZJUy+7iiy+2dU/90khajvCjjz6yxxk/P88p4Y4sET1+++03r1GjRnboVcOr/lW2Tz13FStWtDOV/J47hk2iowemb9++XoYMGexMNg3D+2699VavTp069mtdWWuZsODyFfTUuS+4x015lRpaW7x4cawSOG+88YYdplf7UG6menV1vIFbgj/vM2bMCKwkonNHfGWQTv//3jjl6fo/Gw3nFGbFItWusjSzUT1ymrWmGY5aoLtMmTKBx6jnbsKECbZ3pmTJkua3334z2bJlC+t+I+Wod8WfjabZrbqa7tq1q/2e2kD27NnNfffdZ55++mnbbnQFfuLECbtwd2gvDtzl97hppQjNdixcuLC5/vrrzalTp+ys+vLly9tbgwYNzJw5c8zvv/9uC5oXKVIk3LuOZBT8eX/mmWfMxIkTbW9/8eLF7bmjR48edtSnT58+ts2oV069cTrG5MiRI3Aecmr2awII7JCi/KEQ/+BcrVo1u8SPln3SEIpKVdxzzz2Bx+sDOnbsWLtUmLrP4R4dXP0DdPBBVsPtOggruFO70TCJhlhk1qxZ5rLLLrNlb/wVJaLhAI3/c/LkSRu0aUURLQml44mCOr8dqL2UKlXK3lTSwm9jtBN3+OeQN954w6buqFSJytz45wl93aVLlzhlkILf/2i5EEynbrtw7wTcP4FrKR9dTfk2btxo8+z04VO9OtUV8j+0HTt2tGs5Cgdmd9uEcqTWr19vA7UKFSrYXEq/ft3gwYPN66+/Hm8OjPIsI3kdR5xfO/Ht37/fDB061F74aXmwF198Mc5jE/oa7tC5QqM/usjzBZ8nNmzYYP73v//ZgE8jQNGIwA4pIvigqp45JbVqYXZdQWnIJH/+/GbTpk02uDt27JipUaOGWbdunfnhhx/Mvn37COYcp2ETnaBViFrvu4I1FaP2D8RanF3re/bv39/2wGjNR0TfsWP16tX2olDvf+nSpc3Ro0dtm9D6n7fddps9gQsXgG4Knfxy/Phxc91115n777/fPPvss7HaiobmdU4pU6aMnSih4C9aA/vo/KuR4vwPVM+ePc0LL7xgc+YKFSpke2GUF7Fz505TokQJe1/Dr0uXLrWP37Nnjz1Ah858gjuUY6kZaRpKUZ6Mgnnl0ekkrt5aUZvp1KmTXcRd+VKIzpVH1Ivbvn17e+GnIXoNyeqErvtqG36vHUGde3QO8IO6Xbt22f+Vc12rVi2bZ6ttaiv+uUJBnVam2bZtm827C/5e1An37A24S/WlihcvbhdkltmzZ3vp06f3YmJi7ILMv//+u92uWZCqYebPfqNendu07m+xYsViFSXW16+99ppXuXJlb+PGjYHtfpugFll0efXVV+3s1u+//97e18oRWbNmtXXq5MCBA7YG2ZVXXmnX/oTbK0q0b9/erhnt1zCsUaOGLT68Z88eu+3w4cOBGfRnmCnPrFikHOVGqVadus5nzJhhOnToYEaMGGGHUwYOHGi/ryE3rdkXfMVO/pSb/GETzWrUe7x27Vpzww032O9pBqwmSmiIVsMo6s0VXbFTiyz6LFmyxK77qvYxdepUW+NQE6o0+ervv/82efLksW1FM181cxpuCZ79OmbMGLvur39MaNKkia1/+s4779jheU2Y0RCtfmbZsmWBnrpoHYYVcuyQLOI7+ao0hf+Ba9y4sU161cFYgZ3KEygvRknQmp4O9yR0cN2+fbstOly5cuVAuQJRmQoVH1ZOporMInrzqKpXr24nUmkSlXJyFdRpIo3y7YYMGWLq1KkTuCgQcuzco0L2jz32mPn888/t+ULtREWINQSrfNyDBw/alI4///zT5myr48AvYp8xyjsHovuvR7KfwA8dOmQPsrqiVsKzbipRoAkR/sl69+7dtg6VEufbtWsX5r1HSudK6Wr7119/tZNk9H4rR0Y9MArulDN10003mZiYGDNo0CB7QA4+YSN6jh06YRcsWNDmUSmY02x5XQQob8pfeURtaO7cubYuWXA7IahzjyZD6DyiCz8dP1THUL13Cty07bvvvrPlTYLp3JMxyoM6id6+SiQb/8Cs3hcFaxou0ZI/KmXiH3RVg0zJ8j/++KNdEkgHdM1siuoE1yhIetakCCW7a3hVJW4UxKnGVNWqVc3s2bNtD4wCOr92nSZSqL3oAI3oCeo0CUJpGTpZ+8NtWg5KMxybNm1qt2n4TcOuajPqyYHbVKdQRcnvuOMOe9xQwXqdO0aPHm2PJfPmzYvzMwT4/4fQFslyYH7zzTfNu+++a0/k6hpXDp1O5ipErG50DbFNnz7dFpYsVqyY/drPn4rmXAgX+e+nZjirLXz99dd22FU0C1qBnXpldJAeP358YEUJ5UupTTCUEr15VJo9L/Xq1bO9df423ZRbJ8HBPydyd+mcoXXDf/nlFztbXsPvV1xxhW0XWh9WebmIHzl2uGAqVbJo0SI7CUKLcYvqTCkZXldb7733nr360hWXFnlXoKeDOidwdylgU6+KJkpo4owSn/1ePBUfVo+uComGLvsU7UnP0ea/8qh0caAhOA3Zqy1pMpaCOY4dbgs+Dvg5mArkdf5QOof+V9kkAvv48cnABdHKAcqXE111+x9E5VFpGSjlUekDqp67q666KvBz5EK4TblSyoFSgK8eOR2YNTSvavCaMKPEeOVehgZ2BHXR5Vx5VFdffbWZP3++eeKJJ2L9DMcO9wUfB/xjh4Zgv/zySztpgl7bc+Moigui6eaffPKJLSKr/DkdqP0hVgV3yqPSwt1vvfVWrJ/jw+i2unXr2pwptQ+tEKAhWX9NRw2p6cDNyRnnyqNSoEcelZuC86q1ItF/0bFDedo1a9a05xmVylLwT1uIH0OxSBaqBK7lwpQvo8XcddL2u9BVr0yzHjmRRwf/ffcnQ2hihNb51FJQOpEr0FdpkxUrVnBghm0PyqPSIu7BeVTNmjWzM2I10QZu0sQq5dfqnHHppZcmupQWPXXnRmCHZKPloVSWIDi4C0ZeTPQGd5pUs3jxYhv8V6pUySZDq5eXA3T0Io8q+gQHaXpvH3roIVuLzp9clZDg44SGYjV8j4QR2CFZ6UOqtR114h42bBgH5SgWHNx9//33tqSF1ghWSQsdmP2cO0Diy6PSkBvBv3tURUETZDQM//LLL59zdZng72ki3oIFC2yOrmoZIn7k2CFZ3XPPPWbkyJFmzZo1JMJHueDlwJQb87///c8Ot6j4rIZmCercRh4VEjJt2jRbv3L16tU25zYxQZ2G5Tt37mwrLxDUnRs9dkhRXG275VzlSBK66g7uudMaoFpRQCdxlcjRdtaBdRt5VNEtoeOChtuVm60cy9tvv91kypTpnEGd0jnGjh0bKKmFhJHwhETnv/gS220uHJjdbBNa1klr/ur9VTFZFRwO7qEL5W/X5AnVsdOKAvToRkcelWbNK0UjoaBO/Pw68qjcPWaol1731dum/FoVq1cB4kcffdTe16pF6qX1BQd1fhFrgrrEoccO5/wwjhgxws5qVT7EXXfdZW688Ua7ckR8J/DgbapHpXViVT0cblE5Cl1la8knLe2j0iYqMqtZjKGC28Tw4cPNBx98YE/yKlgMt5FHFd2C31OtNjNnzhxblFxlbVQKy69PqCXjNPSu9aOVphEc3Ok4o3xt/d+iRYuw/S0RR4EdEJ+nn37ay5Url9etWzevfv36XoUKFbxbbrnF+/nnn+33z549G3hs8NdvvfWWlzNnTm/27Nlh2W+knHHjxnl58+b1li9f7h0+fNjbunWrd9NNN9n2MXfu3FiPDW4To0aNsm1i0qRJYdhrhEO9evW8dOnSeQ0aNPD++uuvBB8X2k6yZMnizZgxI5X2Eint+eeft+eRiRMnem+//bb38MMPe0WKFPGee+65wGOaN29u28rixYsD206fPu3179/fmzlzZpj2PHIR2CFeS5Ys8YoXL+59//33gW1TpkzxmjRp4rVo0cI7cODAOU/gn3zySarvM1LeM8884zVu3Nh+/e+//9r/t2/f7lWsWNFr1apVgm0iR44c3tSpU8Owx0gNwe93sLZt23qZMmXyPv74Y+/UqVPn/DnaiXv27dvn1axZ0/vggw8C2/bs2eMNGTLEu+qqq2KdJ3r16hU4pvhC7yNxSHJBvLQ246FDh2Llxagr/M4777QzXpUv4Q/b+t3t77zzjk1w1VBKy5Ytw7bvSH7Kf5Jjx47ZtiHKhzp9+rRdFkxrv2rdz61bt8YagtEi7uTHuC34GKDjgmbA+m1EeVRaM1p5VBqK07BsMPKo3BKa2aWUns2bN9v1f3358uUzbdq0MYUKFbJDs76BAwcG1gH2kaOdNAR2iPVh9EsUKJlVpQdUdyz4MSpArIRX1SITPxdP+TRPPvmknbVELoRbpSqCD7Ba+knvvb8usD+TTY/X2p7+JArRwu69e/c27777Lm3CUTou+McA5VGpfVx77bXmvvvus3Us5dNPPzU1atSw9S3jC+6UP6V8K10Q0k4i16ZNm+ySkqJVZpYuXWpy5sxp14z++eefY5W8yZ8/v11POjiw81HE/sLxCka50PIV/tdaxkc9MQrWrrzySlOqVCm7XVdeBQoUsDffli1bbF0irrbdaxNTpkyxvXAqHqve2vr165s+ffrYHpjjx4/bMgV6rNYC1lJQwTMZtbD79OnTTe3atcP41yAl+UG8SplosoMmW6lXd+XKlea1116zawTrJP/ZZ5/ZoE2TqVTmpnr16vbnFOSpfU2dOtU0btw4zH8Nkhrcr1u3zpQvX95e2C9fvtyeCzTZThMhFOx36tTJTrpTiRP11OnYsWPHDjsZD8mPWbFRLPgErhOzZiapG7xKlSr2Clonc81eUlkL9dTpCkt1h/bt2xdrnU89z+7du+0HFu7o0aOHPeGqByZLliw2SJs5c6Zd/kezWxXg5cqVy35Pvbs6YetA7g/NUZ8uOmj4VUGblodST52od0Y9cTquvPTSS4HUDNW0e+GFF2INsVGvzg1aWUYpGTqnzJs3z1x//fWBtAyN6Cj415rhmumsgF+pPipQTA9d8mMoNor5QZ1yW/r27WtPyvoQ6oSuA7WuplVQVlfXX331VaD8wLJly+yBWAdkfyiGoM4tH3/8sT0x638Fc/fff7/drt6Yyy+/3PbkqldGw2fKo/OXf9KFgdoDQZ27yKNCfPm3KmGkc4aGYzX0qmOFfxxQOaTx48ebhg0b2nOIal/6QV1wW0AySeQkCzhq2bJlXsGCBb3vvvsusG3VqlV2enrr1q0D244dO+b9+eefgVls//zzT1j2F8kvuLSE//6+8sor3iOPPGK/1sy1bNmy2VIFojInmtkWihls7tu4cWOgdEm/fv3s7HmVpdBM+QcffDBOu7jnnntizZaGuzOhNev5+PHj3gsvvOBlyJDBe/PNN+1541w4j6QMeuyinHIddMXt59Dp6qlChQp22E15c1qQW5QUr+E2f3UBus/doN445cC88sor9r5/ha2rbVX/nzFjhunQoYMtMKuhNj/vTj0vGqoPRs+Lu/SZ/+mnn+xxQsXHu3TpYodY1fvi51FphQn14P7+++/2Z/w8KuVawt2Z0DoOqLdWE6lUlF5rQmsUSG1k4sSJth3IAw88YFatWhXreTiPpAxe1SgSX+X3vHnz2nwY5dcpEV4nZz1OB3Dl1B05ciTO8zDM5g5VgX/99ddN9+7d7ZCKDshSrVo1W77knnvusYt1a7KEH/Ap6Newi9Z7RXTQZ75s2bI2P05r/fp5VNdcc409XmjYVccK5VFpuTk/j0oz6LUNbuZma3lAtQOtQKPJEpocoeUClW+nNvP444/b1B0Nx+s8o7I2SHkEdlH4YVSNKZUzEZWo0EFZPTK62tKsR9H3lRRPEOd2m1BwpitrreGqE7bKE+h/rduo3jpdietxmvmsE7UmTOgAre/JuZaJgjv8CQ5+HpUoj6p06dIme/bsgTwqHU+Ue7l+/XpTsWJF23vj51HROxPZ/M+6fx7Re6seWl0Mdu7c2ebhqrdWF4GaCa+JFFp2ULNk1W7mz59v2wCTZVIes2KjjIZPVF/I/2Dq4KsPnq68NGVdH04lPqsLXbPdgme/wh3BAZnqjSlYU3kKnbTVRjSBRidjDZ+oXSjRWbOlNSSviTQafuMA7b7QwF0FqdVG1FZUt04TqjQTVu0iIQR1kU+9sbro8z/zOgZ069bNljVRjUL1yul/pesolUeT8VS/LrQjgbaQSlIodw9p0LBhw+ykiJ49e3qlS5e2S7r4S72sW7fO6927t3fFFVd4NWrU8Jo1a2aTooWkeHdpvUa955ogMXbsWDthQms2Dhw40H7/zJkz3u+//+59++233pYtW+x9IenZff57LSdPnvT2798f6/vPPvusTZLXpBo/Sb5Dhw7eypUrU31fkXJ0Xrjuuuu8vXv3Bj77Wmpy5MiR9v5XX33lXXbZZd6ECRPsOuJaQu6uu+7yvv7660QtO4fkR2AXJQdmfzHmadOmBe5r1mvJkiXtwu7+Oo6a8aiDOLNf3XfkyBEbxL/xxhuBbYcOHfJeeuklG9zpQiAx7QruCX6PBw0a5NWvX98u3P7UU095P/30U6yTfubMme2MWLUlXSxyzHCLzg833nij17Bhw0BwpwoJmgGtY4i+N2DAALtdnQFlypTx0qdPb9d+RXgwKzYKlvpRt7nqkanCu7rKfRMmTLDDa0qO19Cr392uvCtmv7onNOtCwyLKnfPX9RStDaxZsHXq1LFDLUqCDhW8UgncbCPBeVSaXNOkSRMzfPhwuzyc2sSCBQvs95VHpeOH2pDyqH755ZdAHhXcoAkRyqHTe6xhd6Vt6DyilJ2///7b5t5qdSLR/Zo1a9oJFZpogzAJU0CJFBTc5d29e3cvZ86cXqFChWwvTMeOHW2vXLB27drZrvQvvvgiDHuL1O6B2bVrV6CHtmvXrl6tWrXsUHywzp07e1WrVvVq167NEEqU8I8LfurFl19+6ZUqVcpbtGiRvb906VIvY8aM3uWXX+41aNDADsf5Tpw4EfiaHjv3jhk6Bnz00Uf2WKH33u+527Ztm3fllVd6bdu29UaPHu3dcsstXrVq1QLHDNJ4woNLbwf5yc6qGaQraPXYaaaarro0UWLkyJF2mTDfuHHjbO/MLbfcEsa9RmrMiNa6nb169bLtwC93ol4a9cpolmNw/bGnnnrKfPfdd4HeW7hLPXNqC1ou0F8ZQiVLVK5CSfGzZs2yqwa8//77trdO7UI9eHPmzLE/7yfH08vvDv+YoWOFjgGtWrWyM5/VK6eeuz179piiRYvaEiZaeUbLhmlyzcKFCwPHDCZXhUmYAkqksIkTJ3r16tWzSazBV03qoalUqZL34osv2vyIUFxhueuZZ56xEyUmT54cuOKW8ePHezVr1vQKFy5sr7jLli3rlStXLtDzQo+d+8ijQnwWLlxoR3qGDx8ep+dOeZfq/Zfdu3d7Bw4cIDc7jaDHzqFemWC//vqr+e2338yaNWtibVdpi1q1aplPP/3Urh5w4sSJWN/nCstN6rXV2q+zZ8+2hUS13qtyZdSTqyvxjz76yPbaFC5c2K4ioDI3fq4UdercRx4V4qM6hapdqQLmGukJ7rlT75zycXft2mXy589v8uTJY7+vcxG9tuHFq+9Yt/kHH3xgSpYsaU/Sqi2lbvJOnTrZ2mSaGCGqQdW+fXtbfNYfQoHbNLSmBdkLFChgq8BPmjTJLsqtdqPtWg5KS4b5y4b5P8MBOnqG6Vu0aGHfcw2ptW3b1rYPrUyjJaM0PK+LAgV+U6dONYcOHbKP04mceoZuiK/YuIL7J554wrYRFTLX9xXUKbjT11pVRMsR6pziY3JV+FGg2BF6G5U3V65cOfuh00oSKiQ6ZMgQuzTUddddZ2ev+VXigw/qrB7g7sk6uMdOxYZVkFrFRDXLUblTuspWMWLNdtRMWEQn5VFVrlzZHgu0FqyCNq08o5w69cYol04XiP6a0cq5U5Fqjh3uefXVV+3Fns4jPi0Np5xKFaUePXq0PZboOPPNN9+YunXrEtinNeEeC0by8HMblCujXKkVK1YE8mGUT1e9enWvS5cucWbEUpPMLcHv5y+//OItXrzY5kqJCoaqIPHHH39s82FERWfLly/vfffdd2HbZ4QXeVTw6fygGa4XX3yxN2PGjFjf07FCedtqK6+99lqs75GbnbYwzhKhQq+U/fvXX3+9vdrSFbh66XRV/fTTT9seHPXKFCtWzOZL+Og2d7P+WO/evc306dPtkFnBggVN1apV7dV2gwYN7Pc15KarcC0hp14Yf/kfRHceldqPeub83pq33nrL5lFpTVC1Ix95VG727itd57nnnrP/azheFROUcyvKy7322mvtcUPD8V27drXbdd6hxy6NCXdkiQujZaBmzpwZa5tmvhYtWtT7+++/A9vUc/f+++9zZeUwvyfllVdesbNf582bZ+/fe++9Xu7cuQP1yFTDrn///rY3pnLlyiwdF0USmuGsFUf69etne2P8paL02EmTJnnXXnut98QTT6TyniI1e/c3bNjgrVq1KnB/x44d3qOPPmproH766ad2219//eXdfffdsXrymDGfNhHYRfCHcefOnV7Tpk3twbhNmzbeq6++Gthet25d76233op3yIQTuDu0pJM/hCZas/PWW2/13nzzzUCR2ezZs9v1PMUP9nUx0Ldv30DbYFgtuij4V9CWUHD37rvvBo43c+bM4ZjhsKefftrLnz+/XUdcZW3Wr19vt2uN6Mcff9y2B51PVOKmQoUKgbZAUJd2MQ4Xod3mWh5MS39pFuz69ettQrNKmWgoVrPZVJJApSwkdMiEbnM3aEhk0aJFZsqUKWbs2LF2m4ZVNYNRQ6tff/21LW2iCTSa7aryBEqG//77703jxo3t0Kxf0oRhteihpQPXrl1rZ8ar7FHwcnKPPvqoLVTcsWNHezzR8aZ+/fr2mMEyYW4Ini+pkjWfffaZeeedd+zwqtpG8+bNzZIlS+zQu44dmjFfqlQp06xZMzvxym8LTJpJw8IdWSJxgq+OVGi2RIkSXp48eWyCs4oRiwqJqvv8vvvus1dZuk2dOjWMe42Ubg/79u3zWrZs6d100012SR9p1qyZXQpKwyjvvfde4Gd0Ba4rb783BtEhvglSmzZtspOpcuTI4U2bNi3OcnIqYq6i1Wpn9My42xY0/Dp48ODAfb3X1113nVeyZEnvxx9/DPTOBffY0ruf9hHYRdiHUbPV8uXLZ/McNAP2qaeesus3+lXh/ZlNWl1AB+fHHnssznMg8gUfaDXzVUMoVapUsSdpDaVonVetIOEPv2qYrVGjRvZCgGG16EEeFeJ7HzUUr/Sd4sWLew888ECcx+rcERMT482fP59zRwSijl0EmT9/vpkwYYKJiYmxa7vKsWPH7PBaz549zZgxY+zQm09FaDWjTevFFilSJIx7jpTy5JNPmi1btth1G7XWqwoQq6CohtVUn04FqFWrTlRoVkMsmilNUdno8swzz9gUjVOnTpmyZcvaOnU6jmjVANW8fOONN2wdQxUt17C8ZtWrfVCnzg3B76OG2DVrXquNKF1DRae1TUOtmTJlCvyMzhlaYWTixIlh3HMkBTl2EUJL/Dz44IO2eKg+iD4VHG7Tpo0tY6F8K7+Uhdx66612FYrt27eHbb+RcpRfqdw6lar48ssvbQCvJcEU0CuI08LcKmeixdsV4Cs/RkGd2gdBndvIo0Iw/33Ue6uVZ9QeFNxv2rTJlClTxq4eoUL2Kmrv27Fjh70YQAQKd5chEm/NmjW261w5ECtXroz1PXWna6gtmD/DTblVcE+fPn28G264wQ6V+MMsmhGtIdmrr77amzJlSpyfYRjWfeRRwc/F3rhxY+D+9OnT7fBqsWLFvOXLlwe2nzhxwmvQoEEglcMvf+TjmBF56LGLIFoubNq0afZKWl3nq1evDgzHahhOhYmDaXabrtCCC4vCnd4YzYrW0JpuuiLX1bbagJaO09Bs3759A7Me/Z+hp85tep/9mfNaGuree+81LVu2tD0zPrWVFStW2N5+9eRqlrRm3Ae3DWZJRzb10v7xxx/myiuvDGyrXbu2XTbuzz//NDNmzAiM7ChdQ8eJ3Llz2zSOxYsXx3oujhmRhxy7CLRq1Sp7wNYHVB9U5UWo/MmPP/5ov9ZBWlhVwm0qc1OhQgXzv//9zwZxPg3Lvv3223aI5YUXXqAdRAnyqBBfeayPP/7Yrjik1We0nniXLl1s2obahsog+UG82ojajIZlCeYiG4FdhFq3bp1p2rSp7aFp3bq1eeSRR+x29doojwrRQUv+6OCs5X00cSZXrlzm8ccft7276rmLb9kguE299FqoXcuC1atXzwZ8yrNU3UNNsrrttttiHSOYSOMW9cT5wZp6anVc0Hmif//+pmLFirYdaNk4dQaogyA4uPPRJiIbR/sIpd4YDcuq6KwKEW/evNluJ6iLLpoc8dFHH9mJFEqI18xGDcPqIB46NAf3KFALHmbVEJvaxJw5c+zMaFEvnrbr/uDBg+MkyVN82B3Ba/hqgoQu9NQLp3SNfv362XOF2sGIESPMVVddZY8dQ4cOjfP+E9RFNo74EUzDcFqke82aNXbhZnWvI/q0aNHCDs8r0NcstuDZr8xqdBd5VAgWfBH37LPPmocfftgOwyrHUrmUysXWBZ/yK7VSkYI75VmqXBIXf25hKNYBOpGrZpmuvvLnzx/u3UEawFBKdCCPCqGUVzt8+HCba6tyVzlz5rTbFdirxImCfHUEXHfddXb5Qd1XG6JmoTsI7ByhtWGzZMkS7t0AkArIo0J81FOr3EoNx6u+qQpQb9y40U6O0Zq/ag8LFy60vXfvvvuuDfyEPFy38E46gqAOiA7kUSEh6nFTAWKVv1qwYIFdmUZ5mCqNpSF4DcUr8NPkqquvvjrwcwR1buHdBIAIQR4VzkXvud5/Dblq9nPRokXNiy++aNN1VNdUq420bdvWtgu1B780FtzCUCwARBjyqHAuWg5MPbglSpSw9xXA3XzzzTYHc+DAgeHePaQwAjsAiCDkUSGxFNRrGPall16ya4ZrmJ5VRdzHOwwAEZxHpR46BXMK3FSjTkNxCvyWLl1KHlUUU5/N8uXL7dJyqluo4XkFdUyacR89dgAQYd577z1b4kgnaa0606BBA9tbpx48rSGsnjofPXXRS8OxuggoX768bQPBs6nhLgI7AIhA5FHhfBDgRw8COwCIYORRAQjGpx8AIhR5VABC0WMHABGMPCoAwQjsAMAR5FEBILADAABwBJd2AAAAjiCwAwAAcASBHQAAgCMI7AAAABxBYAcAAOAIAjsAAABHENgBAAA4gsAOAADAEQR2AAAAjiCwAwAAMG74f/w9rA54t7jwAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Evaluation times (normalized to pymoo_native):\n",
+      "pymoo_native: 1.0000x\n",
+      "desdeo_polars: 8.7010x\n",
+      "simulator_server: 100.4149x\n",
+      "simulator_script: 1310.6356x\n"
+     ]
+    }
+   ],
+   "source": [
+    "plt.bar(times.keys(), times.values())\n",
+    "plt.ylabel(\"Time (seconds)\")\n",
+    "plt.title(\"Evaluation Times for Different Methods\")\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.yscale(\"log\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Evaluation times (normalized to pymoo_native):\")\n",
+    "for key, value in times.items():\n",
+    "    print(f\"{key}: {value:.4f}x\")  # Print the normalized times"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "51e3f4b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Polars Evaluator output:\n",
+      "shape: (1_000, 17)\n",
+      "┌──────────┬──────────┬──────────┬──────────┬───┬──────────┬──────────┬──────────┬──────────┐\n",
+      "│ x_1      ┆ x_2      ┆ x_3      ┆ x_4      ┆ … ┆ f_3      ┆ f_1_min  ┆ f_2_min  ┆ f_3_min  │\n",
+      "│ ---      ┆ ---      ┆ ---      ┆ ---      ┆   ┆ ---      ┆ ---      ┆ ---      ┆ ---      │\n",
+      "│ f64      ┆ f64      ┆ f64      ┆ f64      ┆   ┆ f64      ┆ f64      ┆ f64      ┆ f64      │\n",
+      "╞══════════╪══════════╪══════════╪══════════╪═══╪══════════╪══════════╪══════════╪══════════╡\n",
+      "│ 0.155762 ┆ 0.174976 ┆ 0.804533 ┆ 0.484207 ┆ … ┆ 0.433937 ┆ 1.672795 ┆ 0.471709 ┆ 0.433937 │\n",
+      "│ 0.560605 ┆ 0.324396 ┆ 0.511785 ┆ 0.180045 ┆ … ┆ 1.027173 ┆ 0.740364 ┆ 0.413701 ┆ 1.027173 │\n",
+      "│ 0.235251 ┆ 0.69323  ┆ 0.325533 ┆ 0.233916 ┆ … ┆ 0.612039 ┆ 0.732316 ┆ 1.400236 ┆ 0.612039 │\n",
+      "│ 0.564268 ┆ 0.195951 ┆ 0.124047 ┆ 0.08441  ┆ … ┆ 1.540688 ┆ 1.198178 ┆ 0.380903 ┆ 1.540688 │\n",
+      "│ 0.531167 ┆ 0.390233 ┆ 0.898066 ┆ 0.348194 ┆ … ┆ 1.296644 ┆ 0.961502 ┆ 0.676281 ┆ 1.296644 │\n",
+      "│ …        ┆ …        ┆ …        ┆ …        ┆ … ┆ …        ┆ …        ┆ …        ┆ …        │\n",
+      "│ 0.604202 ┆ 0.073623 ┆ 0.384575 ┆ 0.81575  ┆ … ┆ 1.703334 ┆ 1.212297 ┆ 0.140826 ┆ 1.703334 │\n",
+      "│ 0.342429 ┆ 0.168498 ┆ 0.976762 ┆ 0.619475 ┆ … ┆ 1.04559  ┆ 1.691665 ┆ 0.458501 ┆ 1.04559  │\n",
+      "│ 0.534179 ┆ 0.025832 ┆ 0.293197 ┆ 0.341606 ┆ … ┆ 1.116179 ┆ 1.001505 ┆ 0.040661 ┆ 1.116179 │\n",
+      "│ 0.520645 ┆ 0.177539 ┆ 0.505405 ┆ 0.596922 ┆ … ┆ 1.003855 ┆ 0.904423 ┆ 0.258972 ┆ 1.003855 │\n",
+      "│ 0.043929 ┆ 0.974703 ┆ 0.943547 ┆ 0.490991 ┆ … ┆ 0.101857 ┆ 0.058546 ┆ 1.472605 ┆ 0.101857 │\n",
+      "└──────────┴──────────┴──────────┴──────────┴───┴──────────┴──────────┴──────────┴──────────┘\n",
+      "Simulator Script Evaluator output:\n",
+      "shape: (1_000, 6)\n",
+      "┌──────────┬──────────┬──────────┬──────────┬──────────┬──────────┐\n",
+      "│ f_1      ┆ f_2      ┆ f_3      ┆ f_1_min  ┆ f_2_min  ┆ f_3_min  │\n",
+      "│ ---      ┆ ---      ┆ ---      ┆ ---      ┆ ---      ┆ ---      │\n",
+      "│ f64      ┆ f64      ┆ f64      ┆ f64      ┆ f64      ┆ f64      │\n",
+      "╞══════════╪══════════╪══════════╪══════════╪══════════╪══════════╡\n",
+      "│ 1.672795 ┆ 0.471709 ┆ 0.433937 ┆ 1.672795 ┆ 0.471709 ┆ 0.433937 │\n",
+      "│ 0.740364 ┆ 0.413701 ┆ 1.027173 ┆ 0.740364 ┆ 0.413701 ┆ 1.027173 │\n",
+      "│ 0.732316 ┆ 1.400236 ┆ 0.612039 ┆ 0.732316 ┆ 1.400236 ┆ 0.612039 │\n",
+      "│ 1.198178 ┆ 0.380903 ┆ 1.540688 ┆ 1.198178 ┆ 0.380903 ┆ 1.540688 │\n",
+      "│ 0.961502 ┆ 0.676281 ┆ 1.296644 ┆ 0.961502 ┆ 0.676281 ┆ 1.296644 │\n",
+      "│ …        ┆ …        ┆ …        ┆ …        ┆ …        ┆ …        │\n",
+      "│ 1.212297 ┆ 0.140826 ┆ 1.703334 ┆ 1.212297 ┆ 0.140826 ┆ 1.703334 │\n",
+      "│ 1.691665 ┆ 0.458501 ┆ 1.04559  ┆ 1.691665 ┆ 0.458501 ┆ 1.04559  │\n",
+      "│ 1.001505 ┆ 0.040661 ┆ 1.116179 ┆ 1.001505 ┆ 0.040661 ┆ 1.116179 │\n",
+      "│ 0.904423 ┆ 0.258972 ┆ 1.003855 ┆ 0.904423 ┆ 0.258972 ┆ 1.003855 │\n",
+      "│ 0.058546 ┆ 1.472605 ┆ 0.101857 ┆ 0.058546 ┆ 1.472605 ┆ 0.101857 │\n",
+      "└──────────┴──────────┴──────────┴──────────┴──────────┴──────────┘\n",
+      "Simulator Server Evaluator output:\n",
+      "shape: (1_000, 16)\n",
+      "┌──────────┬──────────┬──────────┬──────────┬───┬──────────┬──────────┬──────────┬──────────┐\n",
+      "│ x_1      ┆ x_2      ┆ x_3      ┆ x_4      ┆ … ┆ f_3      ┆ f_1_min  ┆ f_2_min  ┆ f_3_min  │\n",
+      "│ ---      ┆ ---      ┆ ---      ┆ ---      ┆   ┆ ---      ┆ ---      ┆ ---      ┆ ---      │\n",
+      "│ f64      ┆ f64      ┆ f64      ┆ f64      ┆   ┆ f64      ┆ f64      ┆ f64      ┆ f64      │\n",
+      "╞══════════╪══════════╪══════════╪══════════╪═══╪══════════╪══════════╪══════════╪══════════╡\n",
+      "│ 0.155762 ┆ 0.174976 ┆ 0.804533 ┆ 0.484207 ┆ … ┆ 0.433937 ┆ 1.672795 ┆ 0.471709 ┆ 0.433937 │\n",
+      "│ 0.560605 ┆ 0.324396 ┆ 0.511785 ┆ 0.180045 ┆ … ┆ 1.027173 ┆ 0.740364 ┆ 0.413701 ┆ 1.027173 │\n",
+      "│ 0.235251 ┆ 0.69323  ┆ 0.325533 ┆ 0.233916 ┆ … ┆ 0.612039 ┆ 0.732316 ┆ 1.400236 ┆ 0.612039 │\n",
+      "│ 0.564268 ┆ 0.195951 ┆ 0.124047 ┆ 0.08441  ┆ … ┆ 1.540688 ┆ 1.198178 ┆ 0.380903 ┆ 1.540688 │\n",
+      "│ 0.531167 ┆ 0.390233 ┆ 0.898066 ┆ 0.348194 ┆ … ┆ 1.296644 ┆ 0.961502 ┆ 0.676281 ┆ 1.296644 │\n",
+      "│ …        ┆ …        ┆ …        ┆ …        ┆ … ┆ …        ┆ …        ┆ …        ┆ …        │\n",
+      "│ 0.604202 ┆ 0.073623 ┆ 0.384575 ┆ 0.81575  ┆ … ┆ 1.703334 ┆ 1.212297 ┆ 0.140826 ┆ 1.703334 │\n",
+      "│ 0.342429 ┆ 0.168498 ┆ 0.976762 ┆ 0.619475 ┆ … ┆ 1.04559  ┆ 1.691665 ┆ 0.458501 ┆ 1.04559  │\n",
+      "│ 0.534179 ┆ 0.025832 ┆ 0.293197 ┆ 0.341606 ┆ … ┆ 1.116179 ┆ 1.001505 ┆ 0.040661 ┆ 1.116179 │\n",
+      "│ 0.520645 ┆ 0.177539 ┆ 0.505405 ┆ 0.596922 ┆ … ┆ 1.003855 ┆ 0.904423 ┆ 0.258972 ┆ 1.003855 │\n",
+      "│ 0.043929 ┆ 0.974703 ┆ 0.943547 ┆ 0.490991 ┆ … ┆ 0.101857 ┆ 0.058546 ┆ 1.472605 ┆ 0.101857 │\n",
+      "└──────────┴──────────┴──────────┴──────────┴───┴──────────┴──────────┴──────────┴──────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Note the difference in the output formats:\n",
+    "\n",
+    "print(\"Polars Evaluator output:\")\n",
+    "print(evaluator_polars.evaluate(inds.to_dict(as_series=False)))\n",
+    "\n",
+    "print(\"Simulator Script Evaluator output:\")\n",
+    "print(evaluator_script.evaluate(inds.to_dict(as_series=False)))\n",
+    "\n",
+    "print(\"Simulator Server Evaluator output:\")\n",
+    "print(evaluator_server.evaluate(inds.to_dict(as_series=False)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c57add4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/BenchExp/pymoo_server.py
+++ b/BenchExp/pymoo_server.py
@@ -1,0 +1,49 @@
+# A FastAPI server to expose pymoo benchmark problems
+
+# lru
+from functools import lru_cache
+from typing import Any
+
+import polars as pl
+from fastapi import FastAPI
+from pydantic import BaseModel
+from pymoo.problems import get_problem
+
+
+class PymooParameters(BaseModel):
+    name: str
+    n_vars: int = 2
+    n_objs: int = 2
+
+
+app = FastAPI()
+
+
+def get_pymoo_problem(name: str, n_vars: int, n_objs: int):
+    """
+    Get a pymoo problem instance by name, number of variables, and number of objectives.
+    """
+    print(name, type(n_vars), type(n_objs))
+    problem = get_problem(name, n_vars=n_vars, n_objs=n_objs)
+    return problem
+
+
+@app.get("/evaluate")
+def evaluate(d: dict[str, list[float]], p: PymooParameters) -> dict[str, Any]:
+    """
+    Evaluate a pymoo problem instance with given parameters and input values.
+    """
+    problem = get_pymoo_problem(p.name, p.n_vars, p.n_objs)
+
+    xs_df = pl.DataFrame(d)
+
+    output = problem.evaluate(xs_df.to_numpy())
+    output_df = pl.DataFrame(output, schema=[f"f_{i+1}" for i in range(problem.n_obj)])
+
+    return d | output_df.to_dict(as_series=False)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app)

--- a/BenchExp/pymoo_simulator.py
+++ b/BenchExp/pymoo_simulator.py
@@ -1,0 +1,67 @@
+import argparse
+import ast
+import json
+import os
+import sys
+
+import numpy as np
+from pymoo.problems import get_problem
+
+
+def simulator_pymoo(variables: dict, parameters: dict) -> dict:
+    # get the problem object from pymoo with its name
+    pymoo_problem = get_problem(parameters["name"], n_var=parameters["n_vars"], n_obj=parameters["n_objs"])
+
+    # get the variable lists
+    vart = [variables[f"x_{i+1}"] for i in range(pymoo_problem.n_var)]
+
+    # stack the variables correctly for pymoo
+    vars = np.stack(vart, axis=1)
+
+    # evaluate the population via pymoo
+    F = pymoo_problem.evaluate(vars)
+
+    # convert the array to dictionary
+    obj = dict([(f"f_{i+1}", F[:, i].tolist()) for i in range(pymoo_problem.n_obj)])
+
+    return obj
+
+
+if __name__ == "__main__":
+    # initialize the argument parser
+    parser = argparse.ArgumentParser()
+
+    # define help messages for when the arguments are missing
+    vars_msg = (
+        "Variables for the simulator as a python dict. For example: {'x_1': [0, 1, 2, 3, 4], 'x_2': [4, 3, 2, 1, 0]}."
+    )
+    params_msg = "Parameters for the simulator as a python dict. For example: {'alpha': 0.1, 'beta': 0.2}."
+
+    # add the expected arguments
+    parser.add_argument("-d", dest="vars", help=vars_msg)
+    parser.add_argument("-p", dest="params", help=params_msg)
+
+    # check that arguments are given, and if not, print out a message with information on the simulator file
+    args = parser.parse_args(args=None if sys.argv[1:] else ["--help"])
+
+    # check that the expected arguments are given values, if not, print out a message with information on the missing argument
+    if args.vars:
+        # parse the argument from string form into a python dict using ast module's literal_eval method
+        variables = ast.literal_eval(args.vars)
+    else:
+        parser.parse_args(["-h"])
+    if args.params:
+        # parse the argument from string form into a python dict using ast module's literal_eval method
+        parameters = ast.literal_eval(args.params)
+    else:
+        parser.parse_args(["-h"])
+
+    stdout = sys.stdout
+    sys.stdout = open(os.devnull, "w")
+
+    # call the simulator with the given variables and parameters
+    simulator_output = simulator_pymoo(variables, parameters)
+
+    # send out the simulator outputs utilizing json.dumps method to keep the output as a dict to be parsed
+    sys.stdout = stdout
+    sys.stdout.write(json.dumps(simulator_output))


### PR DESCRIPTION
DESDEO currently does not have many benchmarking problems. Other packages do. DESDEO can technically call them by treating them as "simulators". This is very slow as DESDEO recreates subprocesses for each new evaluation.

I implemented another way to support simulators (in a very hacky, untested way). The simulator is expected to be accessed through a RestAPI. This seems much faster than the old way (though still very slow compared to native pymoo or DESDEO polars implementations).