### PR TITLE
typo fix: "form Github," -> "from Github,"

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pip install desdeo
 ```
 
 However, some of DESDEO's features rely on 3rd party optimizers, which should be available on your system.
-To read more on these, and on instructions on how to install the latest version of DESDEO directly form GitHub,
+To read more on these, and on instructions on how to install the latest version of DESDEO directly from Github,
 [check out the documentation](https://desdeo.readthedocs.io/en/latest/howtoguides/installing/).
 
 ## Documentation


### PR DESCRIPTION
typo fix in README : "form GitHub," → "from GitHub,"