### PR TITLE
Added logout endpoint and tests for it

### DIFF
--- a/desdeo/api/routers/user_authentication.py
+++ b/desdeo/api/routers/user_authentication.py
@@ -382,6 +382,26 @@ def login(
     return response
 
 
+@router.post("/logout")
+def logout() -> JSONResponse:
+    """Log the current user out. Deletes the refresh token that was set by logging in
+
+    Args:
+        None
+
+    Returns:
+        JSONResponse: A response in which the cookies are deleted
+
+    """
+
+    response = JSONResponse(
+        content={"message": "logged out"},
+        status_code=status.HTTP_200_OK
+    )
+    response.delete_cookie("refresh_token")
+    return response
+
+
 @router.post("/refresh")
 def refresh_access_token(
     request: Response,

--- a/desdeo/api/tests/test_routes.py
+++ b/desdeo/api/tests/test_routes.py
@@ -374,3 +374,31 @@ def test_add_new_analyst(client: TestClient):
     # Trying to create an analyst with username that is already in use should return 409
     assert bad_response.status_code == status.HTTP_409_CONFLICT
 
+
+def test_login_logout(client: TestClient):
+    """Test that logging out works."""
+    
+    # Login (sets refresh token cookie)
+    login(client=client, username="analyst", password="analyst")
+
+    # Refresh access token
+    response = client.post(
+        "/refresh"
+    )
+    # Access token refreshed
+    assert response.status_code == status.HTTP_200_OK
+
+    # Logout (remove the refresh token cookie)
+    response = client.post(
+        "/logout",
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # Refresh access token
+    response = client.post(
+        "/refresh",
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+    # Access token NOT refreshed
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    


### PR DESCRIPTION
An endpoint for logging out.  Also relevant tests.
Technically just deletes the refresh token cookie that's set when logging in.