### PR TITLE
Adding simulator file example to the article examples list

### DIFF
--- a/docs/howtoguides/index.md
+++ b/docs/howtoguides/index.md
@@ -22,3 +22,4 @@ The following examples are the ones, which are covered in the article describing
 
 - **[Example 1](./how_to_define_a_problem.ipynb):** How to define a multiobjective optimization problem
 - **[Example 2](./how_to_utilize_mcdm_methods.ipynb):** How to utilize 'MCDM' methods
+- **[Example 3](../explanation/simulator_support.ipynb):** Connecting DESDEO to a simulator


### PR DESCRIPTION
The notebook added to the list has an example of how to connect a simulator to DESDEO (through a simulator file).

[Here](https://desdeo.readthedocs.io/en/latest/howtoguides/problem/#example-simulation-based-problem) we also have an example of how to define a problem that uses simulators if we want to refer to that as well.