### PR TITLE
Validate problem schemas by name. 

### DIFF
--- a/desdeo/api/routers/problem.py
+++ b/desdeo/api/routers/problem.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status, Request
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
 from desdeo.api.db import get_session
@@ -11,13 +11,6 @@ from desdeo.api.routers.user_authentication import get_current_user
 from desdeo.problem import Problem
 
 router = APIRouter(prefix="/problem")
-
-
-# This is needed, because otherwise fields ending in an underscore fail to parse.
-async def parse_problem_json(request: Request) -> Problem:
-    """Helper function to pass by_name=True to model_validate when coercing the json object to a Problem object."""
-    data: dict = await request.json()
-    return Problem.model_validate(data, by_name=True)
 
 
 @router.get("/all")
@@ -78,7 +71,7 @@ def get_problem(
 
 @router.post("/add")
 def add_problem(
-    request: Annotated[Problem, Depends(parse_problem_json)],
+    request: Problem,
     user: Annotated[User, Depends(get_current_user)],
     session: Annotated[Session, Depends(get_session)],
 ) -> ProblemInfo:

--- a/desdeo/problem/schema.py
+++ b/desdeo/problem/schema.py
@@ -260,7 +260,7 @@ class ObjectiveTypeEnum(str, Enum):
 class Constant(BaseModel):
     """Model for a constant."""
 
-    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid')
+    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid', validate_by_name=True)
 
     name: str = Field(
         description=(
@@ -284,7 +284,13 @@ class Constant(BaseModel):
 class TensorConstant(BaseModel):
     """Model for a tensor containing constant values."""
 
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True, from_attributes=True, extra='forbid')
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        from_attributes=True,
+        extra='forbid',
+        validate_by_name=True
+    )
 
     name: str = Field(description="Descriptive name of the tensor representing the values. E.g., 'distances'")
     """Descriptive name of the tensor representing the values. E.g., 'distances'"""
@@ -377,7 +383,7 @@ class TensorConstant(BaseModel):
 class Variable(BaseModel):
     """Model for a variable."""
 
-    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid')
+    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid', validate_by_name=True)
 
     name: str = Field(
         description="Descriptive name of the variable. This can be used in UI and visualizations. Example: 'velocity'."
@@ -407,7 +413,13 @@ class Variable(BaseModel):
 class TensorVariable(BaseModel):
     """Model for a tensor, e.g., vector variable."""
 
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True, from_attributes=True, extra='forbid')
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+        from_attributes=True,
+        extra='forbid',
+        validate_by_name=True
+    )
 
     name: str = Field(
         description="Descriptive name of the variable. This can be used in UI and visualizations. Example: 'velocity'."
@@ -585,7 +597,7 @@ class ExtraFunction(BaseModel):
     they are needed for other computations related to the problem.
     """
 
-    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid')
+    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid', validate_by_name=True)
 
     name: str = Field(
         description=("Descriptive name of the function. Example: 'normalization'."),
@@ -663,7 +675,7 @@ class ExtraFunction(BaseModel):
 class ScalarizationFunction(BaseModel):
     """Model for scalarization of the problem."""
 
-    model_config = ConfigDict(from_attributes=True, extra='forbid')
+    model_config = ConfigDict(from_attributes=True, extra='forbid', validate_by_name=True)
 
     name: str = Field(description=("Name of the scalarization function."))
     """Name of the scalarization function."""
@@ -715,7 +727,7 @@ class ScalarizationFunction(BaseModel):
 class Simulator(BaseModel):
     """Model for simulator data."""
 
-    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid')
+    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid', validate_by_name=True)
 
     name: str = Field(
         description=("Descriptive name of the simulator. This can be used in UI and visualizations."),
@@ -745,7 +757,7 @@ class Simulator(BaseModel):
 class Objective(BaseModel):
     """Model for an objective function."""
 
-    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid')
+    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid', validate_by_name=True)
 
     name: str = Field(
         description=(
@@ -857,7 +869,7 @@ class Objective(BaseModel):
 class Constraint(BaseModel):
     """Model for a constraint function."""
 
-    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid')
+    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid', validate_by_name=True)
 
     name: str = Field(
         description=(
@@ -960,7 +972,7 @@ class DiscreteRepresentation(BaseModel):
     found at `objective_values['f_i'][j]` for all `i` and some `j`.
     """
 
-    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid')
+    model_config = ConfigDict(frozen=True, from_attributes=True, extra='forbid', validate_by_name=True)
 
     variable_values: dict[str, list[VariableType]] = Field(
         description=(
@@ -999,7 +1011,7 @@ class DiscreteRepresentation(BaseModel):
 class Problem(BaseModel):
     """Model for a problem definition."""
 
-    model_config = ConfigDict(frozen=True, extra='forbid')
+    model_config = ConfigDict(frozen=True, extra='forbid', validate_by_name=True)
 
     _scalarization_index: int = PrivateAttr(default=1)
     # TODO: make init to communicate the _scalarization_index to a new model
@@ -1577,7 +1589,7 @@ class Problem(BaseModel):
         """
         json_data = path.read_text()
 
-        return cls.model_validate_json(json_data, by_name=True)
+        return cls.model_validate_json(json_data)
 
     @model_validator(mode="after")
     def set_is_twice_differentiable(cls, values):


### PR DESCRIPTION
* Improves #290. 
* Removes the need to pass by_name to every validate call, which means that we don't need a helper function for parsing json into problem classes, which should be more elegant. 