### PR TITLE
Metadata fetch

### DIFF
--- a/desdeo/api/db_init.py
+++ b/desdeo/api/db_init.py
@@ -7,7 +7,7 @@ from sqlmodel import Session, SQLModel
 
 from desdeo.api.config import ServerDebugConfig, SettingsConfig
 from desdeo.api.db import engine
-from desdeo.api.models import ProblemDB, User, UserRole
+from desdeo.api.models import ProblemDB, User, UserRole, ProblemMetaDataDB, ForestProblemMetaData
 from desdeo.api.routers.user_authentication import get_password_hash
 from desdeo.problem.testproblems import dtlz2, river_pollution_problem, simple_knapsack
 
@@ -45,6 +45,22 @@ if __name__ == "__main__":
 
             session.commit()
             session.refresh(problem_db)
+
+            # For testing purposes, added some metadata
+            metadata = ProblemMetaDataDB(
+            problem_id=problem_db.id,
+            data = [
+                    ForestProblemMetaData(
+                        map_json = "type: string",
+                        schedule_dict = {"type": "dict"},
+                        years = ["type:", "list", "of", "strings"],
+                        stand_id_field = "type: string",
+                    ),
+                ],
+            )
+            session.add(metadata)
+            session.commit()
+            session.refresh(metadata)
 
         """
         db.add(user_analyst)

--- a/desdeo/api/db_init.py
+++ b/desdeo/api/db_init.py
@@ -45,23 +45,7 @@ if __name__ == "__main__":
 
             session.commit()
             session.refresh(problem_db)
-
-            # For testing purposes, added some metadata
-            metadata = ProblemMetaDataDB(
-            problem_id=problem_db.id,
-            data = [
-                    ForestProblemMetaData(
-                        map_json = "type: string",
-                        schedule_dict = {"type": "dict"},
-                        years = ["type:", "list", "of", "strings"],
-                        stand_id_field = "type: string",
-                    ),
-                ],
-            )
-            session.add(metadata)
-            session.commit()
-            session.refresh(metadata)
-
+            
         """
         db.add(user_analyst)
         db.commit()

--- a/desdeo/api/db_init.py
+++ b/desdeo/api/db_init.py
@@ -7,7 +7,7 @@ from sqlmodel import Session, SQLModel
 
 from desdeo.api.config import ServerDebugConfig, SettingsConfig
 from desdeo.api.db import engine
-from desdeo.api.models import ProblemDB, User, UserRole, ProblemMetaDataDB, ForestProblemMetaData
+from desdeo.api.models import ProblemDB, User, UserRole
 from desdeo.api.routers.user_authentication import get_password_hash
 from desdeo.problem.testproblems import dtlz2, river_pollution_problem, simple_knapsack
 
@@ -45,7 +45,7 @@ if __name__ == "__main__":
 
             session.commit()
             session.refresh(problem_db)
-            
+
         """
         db.add(user_analyst)
         db.commit()

--- a/desdeo/api/models/__init__.py
+++ b/desdeo/api/models/__init__.py
@@ -42,7 +42,9 @@ __all__ = [
     "UserRole",
     "VariableDB",
     "ProblemMetaDataDB",
+    "BaseProblemMetaData",
     "ForestProblemMetaData",
+    "ProblemMetaDataGetRequest",
 ]
 
 from .archive import UserSavedSolutionBase, UserSavedSolutionDB
@@ -65,7 +67,9 @@ from .problem import (
     TensorVariableDB,
     VariableDB,
     ProblemMetaDataDB,
+    BaseProblemMetaData,
     ForestProblemMetaData,
+    ProblemMetaDataGetRequest,
 )
 from .reference_point_method import RPMSolveRequest
 from .session import (

--- a/desdeo/api/models/problem.py
+++ b/desdeo/api/models/problem.py
@@ -71,7 +71,7 @@ class ProblemInfo(ProblemBase):
     tensor_constants: list["TensorConstantDB"] | None
     variables: list["VariableDB"] | None
     tensor_variables: list["TensorVariableDB"] | None
-    objectives: list["ObjectiveDB"] | None
+    objectives: list["ObjectiveDB"]
     constraints: list["ConstraintDB"] | None
     scalarization_funcs: list["ScalarizationFunctionDB"] | None
     extra_funcs: list["ExtraFunctionDB"] | None

--- a/desdeo/api/routers/problem.py
+++ b/desdeo/api/routers/problem.py
@@ -1,12 +1,20 @@
 """Defines end-points to access and manage problems."""
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from desdeo.api.db import get_session
-from desdeo.api.models import ProblemDB, ProblemGetRequest, ProblemInfo, ProblemInfoSmall, User, UserRole
+from desdeo.api.models import (
+    ProblemDB,
+    ProblemGetRequest,
+    ProblemInfo,
+    ProblemInfoSmall,
+    User,
+    UserRole,
+    ProblemMetaDataGetRequest,
+)
 from desdeo.api.routers.user_authentication import get_current_user
 from desdeo.problem import Problem
 
@@ -115,3 +123,32 @@ def add_problem(
     session.refresh(problem_db)
 
     return problem_db
+
+
+@router.post("/get_metadata")
+def get_metadata(
+    request: ProblemMetaDataGetRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    session: Annotated[Session, Depends(get_session)],
+) -> list[Any]:
+    """Fetch specific metadata for a specific problem. See all the possible metadata types from DESDEO/desdeo/api/models/problem.py Problem Metadata section.
+
+    Args:
+        request (MetaDataGetRequest): requesting certain problem's certain metadata
+        user (Annotated[User, Depends]): the current user
+        session (Annotated[Session, Depends]): the database session
+
+    Returns:
+        list[Any] | None: list of all forest metadata for this problem, or nothing if there's nothing
+    """
+    statement = select(ProblemDB).where(ProblemDB.id == request.problem_id)
+    problem_from_db = session.exec(statement).first()
+    if problem_from_db == None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Problem with ID {request.problem_id} not found!"
+        )
+    problem_metadata = problem_from_db.problem_metadata
+    if problem_metadata == None:
+        return []
+    return [metadata for metadata in problem_metadata.data if metadata.metadata_type == request.metadata_type]

--- a/desdeo/api/tests/conftest.py
+++ b/desdeo/api/tests/conftest.py
@@ -7,7 +7,7 @@ from sqlmodel.pool import StaticPool
 
 from desdeo.api.app import app
 from desdeo.api.db import get_session
-from desdeo.api.models import ProblemDB, User, UserRole
+from desdeo.api.models import ProblemDB, User, UserRole, ProblemMetaDataDB, ForestProblemMetaData
 from desdeo.api.routers.user_authentication import get_password_hash
 from desdeo.problem.testproblems import dtlz2, river_pollution_problem
 
@@ -39,6 +39,21 @@ def session_fixture():
         session.add(problem_db_river)
         session.commit()
         session.refresh(problem_db_river)
+
+        metadata = ProblemMetaDataDB(
+        problem_id=problem_db_river.id,
+        data = [
+                ForestProblemMetaData(
+                    map_json = "type: string",
+                    schedule_dict = {"type": "dict"},
+                    years = ["type:", "list", "of", "strings"],
+                    stand_id_field = "type: string",
+                ),
+            ],
+        )
+        session.add(metadata)
+        session.commit()
+        session.refresh(metadata)
 
         yield {"session": session, "user": user_analyst}
         session.rollback()

--- a/desdeo/api/tests/test_routes.py
+++ b/desdeo/api/tests/test_routes.py
@@ -119,6 +119,7 @@ def test_get_problem(client: TestClient):
 
     assert info.id == 1
     assert info.name == "dtlz2"
+    assert info.problem_metadata == None
 
     response = post_json(client, "problem/get", ProblemGetRequest(problem_id=2).model_dump(), access_token)
 
@@ -128,6 +129,7 @@ def test_get_problem(client: TestClient):
 
     assert info.id == 2
     assert info.name == "The river pollution problem"
+    assert info.problem_metadata.data[0].metadata_type == "forest_problem_metadata"
 
 
 def test_add_problem(client: TestClient):
@@ -402,3 +404,41 @@ def test_login_logout(client: TestClient):
     # Access token NOT refreshed
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     
+
+def test_get_problem_metadata(client: TestClient):
+    """Test that fetching problem metadata works."""
+    
+    access_token = login(client=client)
+
+    # Problem with no metadata
+    req = {"problem_id": 1, "metadata_type": "forest_problem_metadata"}
+    response = post_json(
+        client=client, 
+        endpoint="/problem/get_metadata", 
+        json=req, 
+        access_token=access_token
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+    # Problem with forest metadata
+    req = {"problem_id": 2, "metadata_type": "forest_problem_metadata"}
+    response = post_json(
+        client=client, 
+        endpoint="/problem/get_metadata", 
+        json=req, 
+        access_token=access_token
+    )
+    assert response.status_code == 200
+    assert response.json()[0]["metadata_type"] == "forest_problem_metadata"
+    assert response.json()[0]["schedule_dict"] == {"type": "dict"}
+
+    # No problem
+    req = {"problem_id": 3, "metadata_type": "forest_problem_metadata"}
+    response = post_json(
+        client=client, 
+        endpoint="/problem/get_metadata", 
+        json=req, 
+        access_token=access_token
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
ProblemInfo and ProblemInfoSmall now return a listing of all metadata associated with the corresponding problem.

A separate endpoint is then used to fetch the metadata. Metadata requests include the corresponding problem's ID and the requested metadata type as a string that matches with the metadata_type field of different metadata.