### PR TITLE
fixes to desdeo.tools.utils.py

### DIFF
--- a/desdeo/tools/utils.py
+++ b/desdeo/tools/utils.py
@@ -68,7 +68,7 @@ available_solvers = {
         "constructor": PyomoGurobiSolver,
         "options": None
     },
-    "guropipy": {
+    "gurobipy": {
         "constructor": GurobipySolver,
         "options": None,
     },
@@ -166,7 +166,7 @@ def guess_best_solver(problem: Problem) -> BaseSolver:  # noqa: PLR0911
     # check if problem has a discrete definition
     has_discrete = problem.discrete_representation is not None
 
-    if TensorVariable in problem.variables:
+    if True in [type(variable) == TensorVariable for variable in problem.variables]:
         if problem.is_linear and shutil.which("cbc"):
             return available_solvers["pyomo_cbc"]["constructor"]
 


### PR DESCRIPTION
Came across these bugs while testing with data from RPM.
* Line 71: In available_solvers dict, changed key "guropipy" to "gurobipy".
* Line 169: Noticed that despite the problem having TensorVariables, execution of the program didn't enter the if-block.