### PR TITLE
(GUI) Added buttons at the bottom of preferences sidebar

### DIFF
--- a/webui/src/lib/components/custom/preferences-bar/preferences-sidebar.svelte
+++ b/webui/src/lib/components/custom/preferences-bar/preferences-sidebar.svelte
@@ -4,7 +4,10 @@
 	import { writable } from 'svelte/store';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import type { components } from '$lib/api/client-types';
-	import { HorizontalBar } from '$lib/components/visualizations/horizontal-bar';
+	import {
+		HorizontalBar,
+		HorizontalBarRanges
+	} from '$lib/components/visualizations/horizontal-bar';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import ValidatedTextbox from '../validated-textbox/validated-textbox.svelte';
 	import { COLOR_PALETTE } from '$lib/components/visualizations/utils/colors.js';
@@ -142,14 +145,45 @@
 				</div>
 			{/each}
 		{:else if $selectedPreference === 'Ranges'}
-			<p class="mb-2 text-sm text-gray-500">
-				Provide a range for each objective, indicating the minimum and maximum acceptable values.
-			</p>
-			<!-- 			{#each objectives as item}
-				<div class="mb-1">
-					<span>{item.name} (Min: {item.ideal}, Max: {item.nadir})</span>
+			{#each problem.objectives as objective, idx}
+				<div class="mb-4 flex flex-col gap-2">
+					<div class="text-sm font-semibold text-gray-700">
+						{objective.name} ({objective.lowerIsBetter ? 'min' : 'max'})
+					</div>
+					<div class="flex flex-row">
+						<div class="flex w-1/4 flex-col justify-center">
+							<span class="text-sm text-gray-500">Value</span>
+							<ValidatedTextbox
+								placeholder={''}
+								min={objective.ideal < objective.nadir ? objective.ideal : objective.nadir}
+								max={objective.nadir > objective.ideal ? objective.nadir : objective.ideal}
+								value={String($referencePointValues[idx])}
+								onChange={(value: String) => {
+									const val = Number(value);
+									if (!isNaN(val)) handleReferencePointChangeInternal(idx, val);
+								}}
+							/>
+						</div>
+						<div class="w-3/4">
+							<HorizontalBarRanges
+								axisRanges={[
+									objective.ideal < objective.nadir ? objective.ideal : objective.nadir,
+									objective.nadir > objective.ideal ? objective.nadir : objective.ideal
+								]}
+								lowerBound={$referencePointValues[idx]}
+								upperBound={$referencePointValues[idx]}
+								barColor={COLOR_PALETTE[idx % COLOR_PALETTE.length]}
+								direction={objective.lowerIsBetter ? 'min' : 'max'}
+								options={{
+									decimalPrecision: 2,
+									showPreviousValue: false,
+									aspectRatio: 'aspect-[11/2]'
+								}}
+							/>
+						</div>
+					</div>
 				</div>
-			{/each} -->
+			{/each}
 		{:else if $selectedPreference === 'Preferred solution'}
 			<p class="mb-2 text-sm text-gray-500">Select one or multiple preferred solutions.</p>
 			<!-- 			{#each objectives as item}

--- a/webui/src/lib/components/custom/preferences-bar/preferences-sidebar.svelte
+++ b/webui/src/lib/components/custom/preferences-bar/preferences-sidebar.svelte
@@ -2,6 +2,7 @@
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import PreferenceSwitcher from './preference-switcher.svelte';
 	import { writable } from 'svelte/store';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import type { components } from '$lib/api/client-types';
 	import { HorizontalBar } from '$lib/components/visualizations/horizontal-bar';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -13,6 +14,8 @@
 		preference_types,
 		problem,
 		onChange,
+		onIterate,
+		onFinish,
 		showNumSolutions = false,
 		ref = null,
 		referencePointValues = writable(problem.objectives.map((obj: any) => obj.ideal)), // default if not provided
@@ -21,6 +24,8 @@
 		preference_types: string[];
 		problem: ProblemInfo;
 		onChange?: (event: { value: string }) => void;
+		onIterate?: () => void;
+		onFinish?: () => void;
 		showNumSolutions?: boolean;
 		ref?: HTMLElement | null;
 		referencePointValues?: typeof writable<number[]>;
@@ -156,5 +161,31 @@
 			<p>Select a preference type to view options.</p>
 		{/if}
 	</Sidebar.Content>
+	<Sidebar.Footer>
+		<div class="items-right flex justify-end gap-2">
+			<Button
+				variant="default"
+				size="sm"
+				onclick={() => {
+					selectedPreference.set(preference_types[0]);
+					referencePointValues.set(problem.objectives.map((obj: any) => obj.ideal));
+					onIterate?.(selectedPreference, referencePointValues);
+				}}
+			>
+				Iterate
+			</Button>
+			<Button
+				variant="secondary"
+				size="sm"
+				onclick={() => {
+					selectedPreference.set(preference_types[0]);
+					referencePointValues.set(problem.objectives.map((obj: any) => obj.ideal));
+					onFinish?.(referencePointValues);
+				}}
+			>
+				Finish
+			</Button>
+		</div>
+	</Sidebar.Footer>
 	<Sidebar.Rail />
 </Sidebar.Root>

--- a/webui/src/lib/components/custom/preferences-bar/preferences-sidebar.svelte
+++ b/webui/src/lib/components/custom/preferences-bar/preferences-sidebar.svelte
@@ -27,10 +27,6 @@
 		handleReferencePointChange?: (idx: number, newValue: number) => void;
 	}>();
 
-	//let ref: HTMLElement | null = $state(null);
-	//let preference_types: string[] = ['Reference point', 'Ranges', 'Preferred solution'];
-	//export let problem: ProblemInfo | null = null;
-
 	// Store for the currently selected preference type
 	const selectedPreference = writable(preference_types[0]);
 	console.log('Problem in preferences sidebar:', problem);

--- a/webui/src/lib/components/custom/validated-textbox/index.ts
+++ b/webui/src/lib/components/custom/validated-textbox/index.ts
@@ -1,0 +1,1 @@
+export { default as ValidatedTextBox } from "./validated-textbox.svelte";

--- a/webui/src/lib/components/custom/validated-textbox/validated-textbox.svelte
+++ b/webui/src/lib/components/custom/validated-textbox/validated-textbox.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { z } from 'zod';
+
+	export let min: number = 0;
+	export let max: number = 100;
+	export let placeholder: string = `Enter a number (${min}–${max})`;
+
+	export let value: string = '';
+	export let onChange: (value: string) => void = () => {};
+	let error: string | null = null;
+
+	const schema = (min: number, max: number) =>
+		z
+			.string()
+			.refine((val) => /^-?\d*\.?\d+$/.test(val), {
+				message: 'Only numbers are allowed.'
+			})
+			.transform(Number)
+			.refine((num) => num >= min && num <= max, {
+				message: `Value must be between ${min} and ${max}.`
+			});
+
+	function validate(val: string) {
+		const result = schema(min, max).safeParse(val);
+		if (!result.success) {
+			error = result.error.errors[0].message;
+		} else {
+			error = null;
+			onChange(val);
+		}
+		value = val;
+	}
+</script>
+
+<Input
+	type="text"
+	{placeholder}
+	class="max-w-xs"
+	bind:value
+	oninput={(e) => validate(e.currentTarget.value)}
+/>
+{#if error}
+	<p class="mt-1 text-xs text-red-600">{error}</p>
+{/if}

--- a/webui/src/lib/components/visualizations/horizontal-bar/horizontal-bar-ranges.svelte
+++ b/webui/src/lib/components/visualizations/horizontal-bar/horizontal-bar-ranges.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+	/**
+	 * Horizontal bar with two draggable bounds (lower and upper)
+	 * --------------------------------
+	 * @author Giomara Larraga <glarragw@jyu.fi>
+	 * @created July 2025
+	 *
+	 * @description
+	 * Renders a horizontal bar with two draggable markers for lower and upper bounds.
+	 *
+	 * @props
+	 * - axisRanges: [number, number] — lower and upper bounds of the bar
+	 * - lowerBound: number — current lower bound value (draggable)
+	 * - upperBound: number — current upper bound value (draggable)
+	 * - barColor: string — color of the bar
+	 * - direction: 'max' | 'min'
+	 * - options: { decimalPrecision, showPreviousValue, aspectRatio }
+	 * - onChangeBounds?: (lower: number, upper: number) => void — callback when bounds change
+	 *
+	 * @features
+	 * - Two draggable markers for lower and upper bounds.
+	 * - Calls `onChangeBounds` when either marker is moved.
+	 * - Responsive to container size.
+	 */
+
+	import { onMount, onDestroy } from 'svelte';
+	import { roundToDecimal } from '$lib/components/visualizations/utils/math';
+	import * as d3 from 'd3';
+
+	export let axisRanges: [number, number] = [0, 1];
+	export let lowerBound: number = 0.2;
+	export let upperBound: number = 0.8;
+	export let barColor: string = '#4f8cff';
+	export let direction: 'max' | 'min' = 'min';
+
+	export let options: {
+		decimalPrecision: number;
+		showPreviousValue: boolean;
+		aspectRatio: string;
+	} = {
+		decimalPrecision: 2,
+		showPreviousValue: true,
+		aspectRatio: 'aspect-[11/2]'
+	};
+
+	export let onChangeBounds: ((lower: number, upper: number) => void) | undefined = undefined;
+
+	let width = 500;
+	let height = 70;
+	let svg: SVGSVGElement;
+	let container: HTMLDivElement;
+	let resizeObserver: ResizeObserver;
+
+	function drawChart() {
+		d3.select(svg).selectAll('*').remove();
+
+		const margin = { top: 6, right: 30, bottom: 18, left: 30 };
+		const innerWidth = width - margin.left - margin.right;
+		const innerHeight = height - margin.top - margin.bottom;
+
+		const x = d3
+			.scaleLinear()
+			.domain([axisRanges[0], axisRanges[1]])
+			.range([margin.left, width - margin.right]);
+
+		// --- Draw x-axis below the bar ---
+		const xAxis = d3
+			.axisBottom(x)
+			.ticks(6)
+			.tickFormat((d) => d.toString());
+
+		d3.select(svg)
+			.append('g')
+			.attr('transform', `translate(0,${height - margin.bottom})`)
+			.call(xAxis);
+
+		// --- Draw bar background ---
+		d3.select(svg)
+			.append('rect')
+			.attr('x', x(axisRanges[0]))
+			.attr('y', margin.top)
+			.attr('width', x(axisRanges[1]) - x(axisRanges[0]))
+			.attr('height', innerHeight)
+			.attr('fill', '#eee')
+			.attr('rx', 1);
+
+		// --- Draw selected range bar ---
+		const lowerPx = x(lowerBound);
+		const upperPx = x(upperBound);
+		d3.select(svg)
+			.append('rect')
+			.attr('x', Math.min(lowerPx, upperPx))
+			.attr('y', margin.top)
+			.attr('width', Math.abs(upperPx - lowerPx))
+			.attr('height', innerHeight)
+			.attr('fill', barColor)
+			.attr('rx', 1)
+			.attr('opacity', 0.7);
+
+		// --- Draw lower bound marker (draggable) ---
+		const dragLower = d3.drag<SVGCircleElement, unknown>().on('drag', function (event) {
+			let px = Math.max(x(axisRanges[0]), Math.min(x(upperBound), event.x));
+			const newLower = roundToDecimal(x.invert(px), options.decimalPrecision);
+			if (newLower > upperBound) return;
+			lowerBound = Math.min(newLower, upperBound);
+			d3.select(this).attr('cx', x(lowerBound));
+			if (onChangeBounds) onChangeBounds(lowerBound, upperBound);
+			drawChart();
+		});
+
+		d3.select(svg)
+			.append('circle')
+			.attr('cx', x(lowerBound))
+			.attr('cy', margin.top + innerHeight / 2)
+			.attr('r', 9)
+			.attr('fill', '#fff')
+			.attr('stroke', barColor)
+			.attr('stroke-width', 3)
+			.attr('cursor', 'ew-resize')
+			.call(dragLower);
+
+		d3.select(svg)
+			.append('text')
+			.attr('x', x(lowerBound))
+			.attr('y', margin.top - 12)
+			.attr('text-anchor', 'middle')
+			.attr('fill', barColor)
+			.attr('font-size', 13)
+			.text(`L: ${roundToDecimal(lowerBound, options.decimalPrecision)}`);
+
+		// --- Draw upper bound marker (draggable) ---
+		const dragUpper = d3.drag<SVGCircleElement, unknown>().on('drag', function (event) {
+			let px = Math.max(x(lowerBound), Math.min(x(axisRanges[1]), event.x));
+			const newUpper = roundToDecimal(x.invert(px), options.decimalPrecision);
+			if (newUpper < lowerBound) return;
+			upperBound = Math.max(newUpper, lowerBound);
+			d3.select(this).attr('cx', x(upperBound));
+			if (onChangeBounds) onChangeBounds(lowerBound, upperBound);
+			drawChart();
+		});
+
+		d3.select(svg)
+			.append('circle')
+			.attr('cx', x(upperBound))
+			.attr('cy', margin.top + innerHeight / 2)
+			.attr('r', 9)
+			.attr('fill', '#fff')
+			.attr('stroke', barColor)
+			.attr('stroke-width', 3)
+			.attr('cursor', 'ew-resize')
+			.call(dragUpper);
+
+		d3.select(svg)
+			.append('text')
+			.attr('x', x(upperBound))
+			.attr('y', margin.top - 12)
+			.attr('text-anchor', 'middle')
+			.attr('fill', barColor)
+			.attr('font-size', 13)
+			.text(`U: ${roundToDecimal(upperBound, options.decimalPrecision)}`);
+	}
+
+	onMount(() => {
+		resizeObserver = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				const rect = entry.contentRect;
+				width = rect.width;
+				height = rect.height;
+				drawChart();
+			}
+		});
+		resizeObserver.observe(container);
+		drawChart();
+	});
+	onDestroy(() => {
+		resizeObserver.disconnect();
+	});
+
+	$: axisRanges, lowerBound, upperBound, barColor, direction, width, height, options, drawChart();
+</script>
+
+<div class={options.aspectRatio} bind:this={container} style="width: 100%; height: 100%;">
+	<svg bind:this={svg} style="width: 100%; height: 100%;" />
+</div>

--- a/webui/src/lib/components/visualizations/horizontal-bar/horizontal-bar.svelte
+++ b/webui/src/lib/components/visualizations/horizontal-bar/horizontal-bar.svelte
@@ -49,12 +49,10 @@
 	export let direction: 'max' | 'min' = 'min';
 
 	export let options: {
-		barHeight: number;
 		decimalPrecision: number;
 		showPreviousValue: boolean;
 		aspectRatio: string;
 	} = {
-		barHeight: 32,
 		decimalPrecision: 2,
 		showPreviousValue: true,
 		aspectRatio: 'aspect-[11/2]'
@@ -65,7 +63,7 @@
 
 	// --- Internal state ---
 	let width = 500;
-	let height = 70;
+	let height = 70; // initial value, will be updated dynamically
 	let svg: SVGSVGElement;
 	let container: HTMLDivElement;
 	let dragLine: d3.Selection<SVGLineElement, unknown, null, undefined>;
@@ -78,7 +76,7 @@
 	function drawChart() {
 		d3.select(svg).selectAll('*').remove();
 
-		const margin = { top: 2, right: 30, bottom: 2, left: 30 };
+		const margin = { top: 6, right: 30, bottom: 18, left: 30 };
 		const innerWidth = width - margin.left - margin.right;
 		const innerHeight = height - margin.top - margin.bottom;
 
@@ -95,16 +93,16 @@
 
 		d3.select(svg)
 			.append('g')
-			.attr('transform', `translate(0,${innerHeight / 2 + options.barHeight})`)
+			.attr('transform', `translate(0,${height - margin.bottom})`)
 			.call(xAxis);
 
 		// --- Draw bar background ---
 		d3.select(svg)
 			.append('rect')
 			.attr('x', x(axisRanges[0]))
-			.attr('y', innerHeight / 2)
+			.attr('y', margin.top)
 			.attr('width', x(axisRanges[1]) - x(axisRanges[0]))
-			.attr('height', options.barHeight)
+			.attr('height', innerHeight)
 			.attr('fill', direction === 'min' ? '#eee' : barColor)
 			.attr('rx', 1);
 
@@ -114,9 +112,9 @@
 			d3.select(svg)
 				.append('rect')
 				.attr('x', x(axisRanges[0]))
-				.attr('y', innerHeight / 2)
+				.attr('y', margin.top)
 				.attr('width', Math.max(0, solWidth))
-				.attr('height', options.barHeight)
+				.attr('height', innerHeight)
 				.attr('fill', direction === 'min' ? barColor : '#eee')
 				.attr('rx', 1);
 		}
@@ -127,9 +125,9 @@
 			.attr(
 				'points',
 				[
-					[x(axisRanges[0]) - 10, innerHeight / 2 + options.barHeight / 2], // tip (left)
-					[x(axisRanges[0]), innerHeight / 2 + 2], // top right
-					[x(axisRanges[0]), innerHeight / 2 + options.barHeight - 2] // bottom right
+					[x(axisRanges[0]) - 10, margin.top + innerHeight / 2], // tip (left)
+					[x(axisRanges[0]), margin.top + 2], // top right
+					[x(axisRanges[0]), margin.top + innerHeight - 2] // bottom right
 				]
 					.map((p) => p.join(','))
 					.join(' ')
@@ -144,9 +142,9 @@
 			.attr(
 				'points',
 				[
-					[x(axisRanges[1]) + 10, innerHeight / 2 + options.barHeight / 2], // tip (right)
-					[x(axisRanges[1]), innerHeight / 2 + 2], // top left
-					[x(axisRanges[1]), innerHeight / 2 + options.barHeight - 2] // bottom left
+					[x(axisRanges[1]) + 10, margin.top + innerHeight / 2], // tip (right)
+					[x(axisRanges[1]), margin.top + 2], // top left
+					[x(axisRanges[1]), margin.top + innerHeight - 2] // bottom left
 				]
 					.map((p) => p.join(','))
 					.join(' ')
@@ -160,7 +158,7 @@
 			d3.select(svg)
 				.append('circle')
 				.attr('cx', x(previousValue))
-				.attr('cy', innerHeight / 2 + options.barHeight / 2)
+				.attr('cy', margin.top + innerHeight / 2)
 				.attr('r', 6)
 				.attr('fill', '#000')
 				.attr('fill-opacity', 0.5)
@@ -175,8 +173,8 @@
 				.append('line')
 				.attr('x1', x(selectedValue))
 				.attr('x2', x(selectedValue))
-				.attr('y1', innerHeight / 2 - 8)
-				.attr('y2', innerHeight / 2 + options.barHeight + 8)
+				.attr('y1', margin.top - 8)
+				.attr('y2', margin.top + innerHeight + 8)
 				.attr('stroke', '#222')
 				.attr('stroke-width', 2)
 				.attr('cursor', 'ew-resize');
@@ -185,7 +183,7 @@
 				.select(svg)
 				.append('circle')
 				.attr('cx', x(selectedValue))
-				.attr('cy', innerHeight / 2 + options.barHeight / 2)
+				.attr('cy', margin.top + innerHeight / 2)
 				.attr('r', 9)
 				.attr('fill', '#fff')
 				.attr('fill-opacity', 0.9)
@@ -209,7 +207,7 @@
 			d3.select(svg)
 				.append('text')
 				.attr('x', x(selectedValue))
-				.attr('y', innerHeight / 2 - 12)
+				.attr('y', margin.top - 12)
 				.attr('text-anchor', 'middle')
 				.attr('fill', '#222')
 				.attr('font-size', 13)
@@ -223,6 +221,7 @@
 			for (const entry of entries) {
 				const rect = entry.contentRect;
 				width = rect.width;
+				height = rect.height; // dynamically update height
 				drawChart();
 			}
 		});
@@ -241,6 +240,7 @@
 		barColor,
 		direction,
 		width,
+		height,
 		options,
 		drawChart();
 </script>
@@ -249,6 +249,6 @@
     Responsive container for the horizontal bar chart.
     Use the aspect ratio from options.
 -->
-<div class={options.aspectRatio} bind:this={container} style="width: 100%;">
-	<svg bind:this={svg} style="width: 100%; height: 85px;" />
+<div class={options.aspectRatio} bind:this={container} style="width: 100%; height: 100%;">
+	<svg bind:this={svg} style="width: 100%; height: 100%;" />
 </div>

--- a/webui/src/lib/components/visualizations/horizontal-bar/index.ts
+++ b/webui/src/lib/components/visualizations/horizontal-bar/index.ts
@@ -1,2 +1,3 @@
 import HorizontalBar from './horizontal-bar.svelte';
-export { HorizontalBar };
+import HorizontalBarRanges from './horizontal-bar-ranges.svelte';
+export { HorizontalBar, HorizontalBarRanges };

--- a/webui/src/routes/interactive_methods/EMO/+page.svelte
+++ b/webui/src/routes/interactive_methods/EMO/+page.svelte
@@ -37,7 +37,11 @@
 
 <div class="flex min-h-[calc(100vh-3rem)]">
 	{#if problem}
-		<AppSidebar {problem} preference_types={['Reference point']} showNumSolutions={true} />
+		<AppSidebar
+			{problem}
+			preference_types={['Reference point', 'Ranges', 'Preferred solution']}
+			showNumSolutions={true}
+		/>
 	{/if}
 
 	<div class="flex-1">


### PR DESCRIPTION
This pull request introduces enhancements to the `preferences-sidebar.svelte` component and related files, focusing on improving user interaction with preference selection and visualization. Key changes include the addition of new components (`ValidatedTextbox` and `HorizontalBarRanges`), updates to existing visualizations, and the integration of new functionality for handling reference point values and user actions.

### Enhancements to Preference Sidebar:

* **Added support for reference point values and new user actions:**
  - Introduced `referencePointValues` as a writable store to manage dynamic values for objectives.
  - Added `onIterate` and `onFinish` callbacks for user actions, enabling iteration and completion workflows. [[1]](diffhunk://#diff-aa70a281a6aae8d9092d3b24b8afaeffc31982dda5a235e7a25f687d43971bd1R5-R49) [[2]](diffhunk://#diff-aa70a281a6aae8d9092d3b24b8afaeffc31982dda5a235e7a25f687d43971bd1R198-R223)

* **Improved user interface for preference types:**
  - Replaced static text with dynamic UI elements, including `ValidatedTextbox` and `HorizontalBar` components, allowing users to input and visualize values interactively.

### New Components:

* **`ValidatedTextbox` component:**
  - Added a reusable textbox with validation logic using `zod` to ensure numeric inputs within specified ranges. [[1]](diffhunk://#diff-268e549319ada3d78750c1c3ac64f93ad9c82ad19f6e0d23a435feddbdb0699cR1-R45) [[2]](diffhunk://#diff-2fb4a725994306fa68a9be7679918863ff979e9dc981af89126555a5872f93f4R1)

* **`HorizontalBarRanges` component:**
  - Introduced a new visualization for multi-range selection with draggable bounds, enabling users to specify lower and upper limits interactively.

### Updates to Existing Visualizations:

* **Refactored `HorizontalBar` component:**
  - Removed the `barHeight` property and dynamically updated the height based on container dimensions.
  - Adjusted margins and positioning for improved layout consistency. [[1]](diffhunk://#diff-e5ed0d81c45f63f7c906970f24634d64db8a2b30dc91be561889a7734c0fceeeL52-L57) [[2]](diffhunk://#diff-e5ed0d81c45f63f7c906970f24634d64db8a2b30dc91be561889a7734c0fceeeL68-R66) [[3]](diffhunk://#diff-e5ed0d81c45f63f7c906970f24634d64db8a2b30dc91be561889a7734c0fceeeL81-R79) [[4]](diffhunk://#diff-e5ed0d81c45f63f7c906970f24634d64db8a2b30dc91be561889a7734c0fceeeL98-R105) [[5]](diffhunk://#diff-e5ed0d81c45f63f7c906970f24634d64db8a2b30dc91be561889a7734c0fceeeR224)
