### PR TITLE
feat: minimal nimbus initialization endpoint

### DIFF
--- a/desdeo/api/models/__init__.py
+++ b/desdeo/api/models/__init__.py
@@ -18,6 +18,8 @@ __all__ = [
     "NIMBUSBaseState",
     "NIMBUSClassificationRequest",
     "NIMBUSClassificationState",
+    "NIMBUSInitializationRequest",
+    "NIMBUSInitializationState",
     "NIMBUSSaveRequest",
     "NIMBUSSaveState",
     "ObjectiveDB",
@@ -47,25 +49,25 @@ __all__ = [
 
 from .archive import UserSavedSolutionBase, UserSavedSolutionDB
 from .generic import IntermediateSolutionRequest
-from .nimbus import NIMBUSClassificationRequest, NIMBUSSaveRequest
+from .nimbus import NIMBUSClassificationRequest, NIMBUSInitializationRequest, NIMBUSSaveRequest
 from .preference import Bounds, PreferenceBase, PreferenceDB, ReferencePoint
 from .problem import (
     ConstantDB,
     ConstraintDB,
     DiscreteRepresentationDB,
     ExtraFunctionDB,
+    ForestProblemMetaData,
     ObjectiveDB,
     ProblemDB,
     ProblemGetRequest,
     ProblemInfo,
     ProblemInfoSmall,
+    ProblemMetaDataDB,
     ScalarizationFunctionDB,
     SimulatorDB,
     TensorConstantDB,
     TensorVariableDB,
     VariableDB,
-    ProblemMetaDataDB,
-    ForestProblemMetaData,
 )
 from .reference_point_method import RPMSolveRequest
 from .session import (
@@ -79,6 +81,7 @@ from .state import (
     IntermediateSolutionState,
     NIMBUSBaseState,
     NIMBUSClassificationState,
+    NIMBUSInitializationState,
     NIMBUSSaveState,
     RPMBaseState,
     RPMState,

--- a/desdeo/api/models/nimbus.py
+++ b/desdeo/api/models/nimbus.py
@@ -30,3 +30,11 @@ class NIMBUSSaveRequest(SQLModel):
     parent_state_id: int | None = Field(default=None)
 
     solutions: list[UserSavedSolverResults]  # List of solutions to save
+class NIMBUSInitializationRequest(SQLModel):
+    """Model of the request to the nimbus method."""
+
+    problem_id: int
+    session_id: int | None = Field(default=None)
+    parent_state_id: int | None = Field(default=None)
+
+    solver: str | None = Field(default=None)

--- a/desdeo/api/models/state.py
+++ b/desdeo/api/models/state.py
@@ -20,7 +20,12 @@ class StateType(TypeDecorator):
 
     def process_bind_param(self, value, dialect):
         """State to JSON."""
-        if isinstance(value, RPMState | NIMBUSClassificationState | IntermediateSolutionState | NIMBUSSaveState):
+        if isinstance(value,
+                      RPMState
+                      | NIMBUSClassificationState
+                      | IntermediateSolutionState
+                      | NIMBUSSaveState
+                      | NIMBUSInitializationState):
             return value.model_dump()
 
         msg = f"No JSON serialization set for ste of type '{type(value)}'."
@@ -36,6 +41,8 @@ class StateType(TypeDecorator):
                     return RPMState.model_validate(value)
                 case ("nimbus", "solve_candidates"):
                     return NIMBUSClassificationState.model_validate(value)
+                case ("nimbus", "initialize"):
+                    return NIMBUSInitializationState.model_validate(value)
                 case ("nimbus", "save_solutions"):
                     return NIMBUSSaveState.model_validate(value)
                 case ("generic", _):
@@ -104,6 +111,13 @@ class NIMBUSSaveState(NIMBUSBaseState):
     """State of the nimbus method for saving solutions."""
 
     phase: Literal["save_solutions"] = "save_solutions"
+    solver_results: list[SolverResults] = Field(sa_column=Column(JSON))
+
+class NIMBUSInitializationState(NIMBUSBaseState):
+    """State of the nimbus method for computing solutions."""
+
+    phase: Literal["initialize"] = "initialize"
+    solver: str | None = Field(default=None)
     solver_results: list[SolverResults] = Field(sa_column=Column(JSON))
 
 class IntermediateSolutionState(BaseState):

--- a/desdeo/api/tests/test_routes.py
+++ b/desdeo/api/tests/test_routes.py
@@ -8,6 +8,7 @@ from desdeo.api.models import (
     GetSessionRequest,
     InteractiveSessionDB,
     NIMBUSClassificationRequest,
+    NIMBUSInitializationRequest,
     NIMBUSSaveRequest,
     NIMBUSSaveState,
     ProblemGetRequest,
@@ -271,6 +272,7 @@ def test_save_solution(client: TestClient):
             message="This is a test solution saved from the NIMBUS method."
         )
     ]
+    
 
     # Create the save request
     save_request = NIMBUSSaveRequest(
@@ -298,6 +300,19 @@ def test_save_solution(client: TestClient):
     assert saved_result.constraint_values == constraint_values
     assert saved_result.extra_func_values == extra_func_values
     assert not hasattr(saved_result, "name")  # Name should not be in state
+
+def test_nimbus_initialize_no_solver(client: TestClient):
+    """Test that initializing NIMBUS works without specifying a solver."""
+    access_token = login(client)
+
+    request = NIMBUSInitializationRequest(
+        problem_id=1,
+        solver=None
+    )
+
+    response = post_json(client, "/method/nimbus/initialize", request.model_dump(), access_token)
+    assert response.status_code == status.HTTP_200_OK
+
 
 def test_add_new_dm(client: TestClient):
     """Test that adding a decision maker works"""


### PR DESCRIPTION
I created an endpoint for initializing nimbus. 
This returns a state with solver_results created with generate_starting_point function.
I created NIMBUSInitializationRequest and -State for this.

I didn't find out all that it should do, but as far as I understood, the start_results are the main thing and what I think I need when I continue figuring out GUI.

"It should also probably try to figure out if this is the first time of loading up the specific problem or not, and act accordingly", but for now it doesn't, because I don't know what this includes. Maybe calculate ideal and nadir if they don't exist? Something else?
I can come back to this later if needed.