### PR TITLE
Endpoint solver fix

### DIFF
--- a/desdeo/api/routers/generic.py
+++ b/desdeo/api/routers/generic.py
@@ -18,6 +18,7 @@ from desdeo.api.routers.user_authentication import get_current_user
 from desdeo.mcdm.nimbus import solve_intermediate_solutions
 from desdeo.problem import Problem
 from desdeo.tools import SolverResults
+from desdeo.tools.utils import available_solvers
 
 router = APIRouter(prefix="/method/generic")
 
@@ -93,6 +94,7 @@ def solve_intermediate(
     # Get solution variables
     solution_1 = solution1_full.optimal_variables
     solution_2 = solution2_full.optimal_variables
+    solver = available_solvers[request.solver]["constructor"] if request.solver is not None else None
 
     solver_results: list[SolverResults] = solve_intermediate_solutions(
         problem=problem,
@@ -100,7 +102,7 @@ def solve_intermediate(
         solution_2=solution_2,
         num_desired=request.num_desired,
         scalarization_options=request.scalarization_options,
-        solver=request.solver,
+        solver=solver,
         solver_options=request.solver_options,
     )
 

--- a/desdeo/api/routers/nimbus.py
+++ b/desdeo/api/routers/nimbus.py
@@ -35,6 +35,7 @@ from desdeo.api.utils.database import user_save_solutions
 from desdeo.mcdm.nimbus import generate_starting_point, solve_sub_problems
 from desdeo.problem import Problem
 from desdeo.tools import SolverResults
+from desdeo.tools.utils import available_solvers
 
 router = APIRouter(prefix="/method/nimbus")
 
@@ -160,6 +161,7 @@ def solve_solutions(
         )
 
     problem = Problem.from_problemdb(problem_db)
+    solver = available_solvers[request.solver]["constructor"] if request.solver is not None else None
 
     solver_results: list[SolverResults] = solve_sub_problems(
         problem=problem,
@@ -167,7 +169,7 @@ def solve_solutions(
         reference_point=request.preference.aspiration_levels,
         num_desired=request.num_desired,
         scalarization_options=request.scalarization_options,
-        solver=request.solver,
+        solver=solver,
         solver_options=request.solver_options,
     )
     # create a new preference in the DB
@@ -362,10 +364,12 @@ def initialize(
             saved_solutions=saved_solutions,
             all_solutions=all_solutions
         )
+    
+    solver = available_solvers[request.solver]["constructor"] if request.solver is not None else None
     # if there is no last nimbus state, generate a starting point and create an initialization state
     start_result = generate_starting_point(
                 problem=problem,
-                solver=request.solver,
+                solver=solver,
             )
     # fetch parent state if it is given
     if request.parent_state_id is None:

--- a/desdeo/api/routers/reference_point_method.py
+++ b/desdeo/api/routers/reference_point_method.py
@@ -19,6 +19,7 @@ from desdeo.api.routers.user_authentication import get_current_user
 from desdeo.mcdm import rpm_solve_solutions
 from desdeo.problem import Problem
 from desdeo.tools import SolverResults
+from desdeo.tools.utils import available_solvers
 
 router = APIRouter(prefix="/method/rpm")
 
@@ -57,13 +58,14 @@ def solve_solutions(
         )
 
     problem = Problem.from_problemdb(problem_db)
+    solver = available_solvers[request.solver]["constructor"] if request.solver is not None else None
 
     # optimize for solutions
     solver_results: list[SolverResults] = rpm_solve_solutions(
         problem,
         request.preference.aspiration_levels,
         request.scalarization_options,
-        request.solver,
+        solver,
         request.solver_options,
     )
 

--- a/desdeo/api/tests/test_routes.py
+++ b/desdeo/api/tests/test_routes.py
@@ -338,6 +338,7 @@ def test_nimbus_solve(client: TestClient):
         current_objectives=result.current_solutions[0].objective_values,
         num_desired=3,
         parent_state_id=result.state_id,
+        solver="pyomo_bonmin" # let's try solving with a specified solver
     )
 
     response = post_json(client, "/method/nimbus/solve", request.model_dump(), access_token)
@@ -454,6 +455,16 @@ def test_nimbus_initialize_no_solver(client: TestClient):
     access_token = login(client)
 
     request = NIMBUSInitializationRequest(problem_id=1, solver=None)
+
+    response = post_json(client, "/method/nimbus/initialize", request.model_dump(), access_token)
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_nimbus_initialize_with_solver(client: TestClient):
+    """Test that initializing NIMBUS works with specifying a solver."""
+    access_token = login(client)
+
+    request = NIMBUSInitializationRequest(problem_id=1, solver="pyomo_bonmin")
 
     response = post_json(client, "/method/nimbus/initialize", request.model_dump(), access_token)
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Came across this bug.

For NIMBUS, RPM and generic routers it seems that specifying a solver in the request hasn't been working. The string representation never gets converted to the actual solver; we send a string over where a BaseSolver is required.

This should fix this issue, at least for NIMBUS, RPM and generic solve_intermediate.