### PR TITLE
fix and feat: One more endpoint, fix typos in generic route, change NIMBUSIntermediateSolutionResponse, NIMBUS UI

### DIFF
--- a/desdeo/api/models/nimbus.py
+++ b/desdeo/api/models/nimbus.py
@@ -92,10 +92,10 @@ class NIMBUSIntermediateSolutionResponse(SQLModel):
     """The response from NIMBUS classification endpoint."""
 
     state_id: int | None = Field(description="The newly created state id")
-    reference_solution_1: SolutionReferenceResponse = Field(
+    reference_solution_1: dict[str, float] = Field(
         sa_column=Column(JSON), description="The first solution used when computing intermediate points."
     )
-    reference_solution_2: SolutionReferenceResponse = Field(
+    reference_solution_2: dict[str, float]= Field(
         sa_column=Column(JSON), description="The second solution used when computing intermediate points."
     )
     current_solutions: list[SolutionReferenceResponse] = Field(

--- a/desdeo/api/routers/generic.py
+++ b/desdeo/api/routers/generic.py
@@ -77,7 +77,7 @@ def solve_intermediate(
 
         try:
             _obj_values = solution_state.state.result_objective_values
-            obj_values = _var_values[solution_info.solution_index]
+            obj_values = _obj_values[solution_info.solution_index]
 
         except IndexError as exc:
             raise HTTPException(
@@ -136,8 +136,8 @@ def solve_intermediate(
         solver_options=request.solver_options,
         solver_results=solver_results,
         num_desired=request.num_desired,
-        reference_solution_1=var_and_obj_values_of_references[0][0],
-        reference_solution_2=var_and_obj_values_of_references[1][0],
+        reference_solution_1=var_and_obj_values_of_references[0][1],
+        reference_solution_2=var_and_obj_values_of_references[1][1],
     )
 
     # create DB state and add it to the DB

--- a/webui/src/lib/components/custom/nimbus/intermediate-sidebar.svelte
+++ b/webui/src/lib/components/custom/nimbus/intermediate-sidebar.svelte
@@ -3,7 +3,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import type { components } from '$lib/api/client-types';
 	import { Input } from '$lib/components/ui/input/index.js';
-	type Solution = components['schemas']['UserSavedSolutionAddress'];
+	type Solution = components['schemas']['SolutionReferenceResponse'];
 
 		interface Props {
 		onChange?: (event: { value: string}) => void;
@@ -71,7 +71,7 @@
 							{#if solution.name}
                                 <div class="font-medium text-primary">{solution.name}</div>
                             {:else}
-                                <div class="font-medium text-primary">Solution {solution.address_result + 1} (iteration {solution.address_state})</div>
+								<div class="font-medium text-primary">Solution {solution.solution_index!== null ? (solution.solution_index+1) : ""} (iteration {solution.state_id})</div> 
                             {/if}
 					</div>
 				{/each}

--- a/webui/src/lib/components/custom/nimbus/solution-table.svelte
+++ b/webui/src/lib/components/custom/nimbus/solution-table.svelte
@@ -90,7 +90,7 @@
 
     // Types matching your original solution-table
     type ProblemInfo = components['schemas']['ProblemInfo'];
-    type Solution = components['schemas']['UserSavedSolutionAddress'];
+    type Solution = components['schemas']['SolutionReferenceResponse'];
     
     // Props matching your original solution-table for compatibility
     let {
@@ -163,7 +163,7 @@
             ...problem.objectives.map((objective, idx) => ({
                 accessorKey: `objective_values.${objective.symbol}`,
                 header: ({ column }: { column: Column<Solution> }) => renderSnippet(ColumnHeader, {column, objective, idx}),
-                cell: ({ row }: { row: Row<Solution> }) => renderSnippet(ObjectiveCell, {value: row.original.objective_values[objective.symbol], accuracy: displayAccuracy()}),
+                cell: ({ row }: { row: Row<Solution> }) => renderSnippet(ObjectiveCell, {value: row.original.objective_values?.[objective.symbol], accuracy: displayAccuracy()}),
                 enableSorting: true
             }))
         ];
@@ -353,7 +353,7 @@
         {#if solution.name}
             {solution.name}
         {:else}
-            <span class="text-gray-400">Solution {solution.address_result + 1}</span>
+            <span class="text-gray-400">Solution {solution.solution_index!== null ? (solution.solution_index+1) : ""}</span>
         {/if}
     </div>
 {/snippet}
@@ -377,12 +377,12 @@
 {/snippet}
 
 {#snippet IterationCell({ solution }: { solution: Solution })}
-        {solution.address_state}
+        {solution.state_id}
 {/snippet}
 
-{#snippet ObjectiveCell({ value, accuracy }: { value: number, accuracy: number })}
+{#snippet ObjectiveCell({ value, accuracy }: { value: number | null | undefined, accuracy: number })}
     <div class="text-right pr-4">
-        {formatNumber(value, accuracy)}
+        {value != null ? formatNumber(value, accuracy) : '-'}
     </div>
 {/snippet}
 

--- a/webui/src/lib/helpers/index.ts
+++ b/webui/src/lib/helpers/index.ts
@@ -80,16 +80,16 @@ export function getDisplayAccuracy(problem: ProblemInfo | null): number {
     // Default to 2 significant digits if not specified
     const DEFAULT_ACCURACY = SIGNIFICANT_DIGITS;
     
-    if (!problem || !problem.problem_metadata || !problem.problem_metadata.data) {
+    if (!problem || !problem.problem_metadata ) {
         return DEFAULT_ACCURACY;
     }
 
-    // Check if any metadata has display_accuracy field
-    for (const meta of problem.problem_metadata.data) {
-        if ('display_accuracy' in meta && typeof meta.display_accuracy === 'number') {
-            return meta.display_accuracy;
-        }
-    }
+    // Check if any metadata has display_accuracy field 
+    // TODO: this does not make sense: I dont know where in the metadata the display accuracy would exist, since it doesn't,
+    // and also it should be unique for every objective value.
+      if ('display_accuracy' in problem.problem_metadata && typeof problem.problem_metadata.display_accuracy === 'number') {
+          return problem.problem_metadata.display_accuracy;
+      }
 
     return DEFAULT_ACCURACY;
 }

--- a/webui/src/routes/interactive_methods/NIMBUS/+server.ts
+++ b/webui/src/routes/interactive_methods/NIMBUS/+server.ts
@@ -77,14 +77,14 @@ export const POST: RequestHandler = async ({ url, request, cookies }) => {
 };
 
 async function handle_save(body: any, refreshToken: string) {
-        const {problem_id, solutions} = body;
+        const {problem_id, solution_info} = body;
         const session_id = null;
         const parent_state_id = null;
         const requestBody = {
             problem_id,
             session_id,
             parent_state_id,
-            solutions
+            solution_info
         }
         const response = await api.POST('/method/nimbus/save', {
             body: requestBody,
@@ -117,7 +117,7 @@ async function handle_initialize(body: any, refreshToken: string) {
         solver
     };
 
-    const response = await api.POST('/method/nimbus/initialize', {
+    const response = await api.POST('/method/nimbus/get-or-initialize', {
         body: requestBody,
         headers: {
             'Authorization': `Bearer ${refreshToken}`


### PR DESCRIPTION
What I did in backend:
- I added a get-or-initialize endpoint to nimbus.py, point being that it acts like the previous initialize-endpoint and UI does not have to change much.
- I fixed the typos in solve_intermediate in generic.py
- I changed the type of reference solutions in NIMBUSIntermediateSolutionResponse to dict[str, float], because I dont see a need for more in UI, the previous_objectives in NIMBUSClassificationResponse are also just a dict, and also these are dicts in IntermediateSolutionState, so it was just simpler in get-or-initialize to use these values as they are in db.

In frontend:
- I changed the types and names etc
- fixed the use of problem metadata, since it has changed too.
- use the get-or-initialize instead of initialize -endpoint