### PR TITLE
Codex/enhance e nautilus interface for session settings

### DIFF
--- a/webui/src/routes/interactive_methods/E-NAUTILUS/+page.svelte
+++ b/webui/src/routes/interactive_methods/E-NAUTILUS/+page.svelte
@@ -32,7 +32,8 @@
 	let representative = $state<ENautilusRepresentativeSolutionsResponse | null>(null);
 	let final_selected_index = $state<number>(0);
 
-	let selection = $state<MethodSelectionState>({ selectedProblemId: null, selectedMethod: null });
+	let selection = $state<MethodSelectionState>({ selectedProblemId: null, selectedMethod: null, selectedSessionId: null, selectedSessionInfo: null
+	});
 	let problem_info = $state<ProblemInfo | null>(null);
 	let previous_request = $state<ENautilusStepRequest | null>(null);
 	let previous_response = $state<ENautilusStepResponse | null>(null);
@@ -287,7 +288,7 @@
 				errorMessage.set("Failed to fetch previous E-NAUTILUS state.");
 				return;
 			}
-			
+
 			previous_request = state_resp.request;
 			previous_response = state_resp.response;
 
@@ -433,8 +434,8 @@
 
 		<div class="grid gap-4 md:grid-cols-2">
 			<div>
-				<label class="mb-1 block text-sm font-medium text-gray-700">Selected session</label>
-				<div class="rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
+				<label class="mb-1 block text-sm font-medium text-gray-700" for="selected-session">Selected session</label>
+				<div class="rounded border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700" id="selected-session">
 					{#if selection.selectedSessionId != null}
 						Session #{selection.selectedSessionId}
 						{#if selection.selectedSessionInfo}

--- a/webui/src/routes/interactive_methods/E-NAUTILUS/handler.ts
+++ b/webui/src/routes/interactive_methods/E-NAUTILUS/handler.ts
@@ -2,7 +2,6 @@ import type { ENautilusRepresentativeSolutionsResponse, ENautilusStateResponse, 
 import type { getRepresentativeMethodEnautilusGetRepresentativeStateIdGetResponse, getStateMethodEnautilusGetStateStateIdGetResponse, stepMethodEnautilusStepPostResponse } from "$lib/gen/endpoints/DESDEOFastAPI";
 import { stepMethodEnautilusStepPost, getProblemProblemGetPost, getStateMethodEnautilusGetStateStateIdGet, getRepresentativeMethodEnautilusGetRepresentativeStateIdGet } from "$lib/gen/endpoints/DESDEOFastAPI";
 import type { getProblemProblemGetPostResponse } from "$lib/gen/endpoints/DESDEOFastAPI";
-import { GetRepresentativeMethodEnautilusGetRepresentativeStateIdGetResponse } from "$lib/gen/endpoints/DESDEOFastAPIzod";
 
 export type ENautilusStepBundle = {
     request: ENautilusStepRequest;
@@ -42,7 +41,6 @@ export async function step_enautilus(
         number_of_intermediate_points: number_of_intermediate_points,
         parent_state_id: current_state.state_id ?? undefined,
         session_id: session_id,
-        //session id
     }
 
     console.log(request);


### PR DESCRIPTION
### Motivation
- E-NAUTILUS was initializing with hard-coded parameters and did not pick up the interactive session chosen by the user, preventing session-scoped states from being used by the backend.

### Description
- Add a startup panel in `webui/src/routes/interactive_methods/E-NAUTILUS/+page.svelte` that collects the selected session, initial number of iterations, and number of intermediate points and prevents initialization until these are provided.
- Pass the chosen `session_id` in the initialization request and in subsequent steps so backend calls include the selected interactive session.
- Update `webui/src/routes/interactive_methods/E-NAUTILUS/handler.ts` to accept a `session_id` parameter and to include it in the `ENautilusStepRequest` payload.
- Add client-side state and validations (`initial_intermediate_points`, `initial_iterations_left`, `has_initialized`) and adjust the `effective_iterations_left` fallback to use the provided initial value.