### PR TITLE
Implementation of something that vaguely resembles SMS-EMOA (cursed!)

### DIFF
--- a/desdeo/emo/__init__.py
+++ b/desdeo/emo/__init__.py
@@ -17,7 +17,6 @@ __all__ = [
 from types import SimpleNamespace
 
 from .options.algorithms import (
-    emo_constructor,
     ibea_mixed_integer_options,
     ibea_options,
     nsga2_options,
@@ -25,6 +24,7 @@ from .options.algorithms import (
     nsga3_options,
     rvea_mixed_integer_options,
     rvea_options,
+    smsemoa_options,
 )
 from .options.crossover import (
     BlendAlphaCrossoverOptions,
@@ -70,6 +70,7 @@ from .options.templates import (
     ReferencePointOptions,
     Template1Options,
     Template2Options,
+    emo_constructor,
 )
 from .options.termination import (
     CompositeTerminatorOptions,
@@ -85,6 +86,7 @@ algorithms = SimpleNamespace(
     nsga2_options=nsga2_options,
     nsga3_options=nsga3_options,
     ibea_options=ibea_options,
+    smsemoa_options=smsemoa_options,
     rvea_mixed_integer_options=rvea_mixed_integer_options,
     nsga3_mixed_integer_options=nsga3_mixed_integer_options,
     ibea_mixed_integer_options=ibea_mixed_integer_options,

--- a/desdeo/emo/operators/selection.py
+++ b/desdeo/emo/operators/selection.py
@@ -6,11 +6,12 @@ TODO:@light-weaver
 
 import warnings
 from abc import abstractmethod
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from enum import StrEnum
 from itertools import combinations
-from typing import Callable, Literal, TypeVar
+from typing import Literal, TypeVar
 
+import moocore
 import numpy as np
 import polars as pl
 from numba import njit
@@ -30,7 +31,7 @@ from desdeo.tools.message import (
     SelectorMessageTopics,
     TerminatorMessageTopics,
 )
-from desdeo.tools.non_dominated_sorting import fast_non_dominated_sort
+from desdeo.tools.non_dominated_sorting import dominates, fast_non_dominated_sort
 from desdeo.tools.patterns import Publisher, Subscriber
 
 SolutionType = TypeVar("SolutionType", list, pl.DataFrame)
@@ -1776,3 +1777,340 @@ class NSGA2Selector(BaseSelector):
 
     def update(self, message: Message) -> None:
         pass
+
+
+_BIOBJECTIVE = 2  # Number of objectives for which the fast exact 2D hypervolume contribution is used.
+
+
+@njit
+def _hv_contributions_2d(front: np.ndarray) -> np.ndarray:
+    """Compute exact exclusive hypervolume contributions for a 2-objective non-dominated front.
+
+    The two boundary (extremal) solutions are assigned an infinite contribution so that they are always
+    kept, following the boundary handling of the SMS-EMOA in the bi-objective case.
+
+    Args:
+        front (np.ndarray): A 2D array (n x 2) of mutually non-dominated objective vectors in minimization form.
+
+    Returns:
+        np.ndarray: A 1D array of length n with the exclusive hypervolume contribution of each solution. The two
+            extremal solutions are assigned ``np.inf``.
+    """
+    n = front.shape[0]
+    contrib = np.full(n, np.inf)
+    if n <= _BIOBJECTIVE:
+        # A bi-objective front with at most two points consists only of boundary solutions, which are kept.
+        return contrib
+    # Sort by the first objective (ascending). Because the front is mutually non-dominated, this also orders
+    # the second objective in descending order.
+    order = np.argsort(front[:, 0])
+    for r in range(1, n - 1):
+        i = order[r]
+        nxt = order[r + 1]
+        prv = order[r - 1]
+        contrib[i] = (front[nxt, 0] - front[i, 0]) * (front[prv, 1] - front[i, 1])
+    return contrib
+
+
+@njit
+def _count_dominating_points(fitness: np.ndarray, candidates: np.ndarray) -> np.ndarray:
+    """Count, for each candidate, how many solutions in ``fitness`` dominate it.
+
+    This implements the d(s, P(t)) measure of the "dominating points" SMS-EMOA variant (Algorithm 3 in the
+    reference). It is computed over the whole (currently alive) population ``fitness``.
+
+    Args:
+        fitness (np.ndarray): A 2D array (n x m) of objective vectors in minimization form (the whole population).
+        candidates (np.ndarray): Indices (into ``fitness``) of the solutions for which to count dominating points.
+
+    Returns:
+        np.ndarray: A 1D array with the number of dominating points for each candidate.
+    """
+    n = fitness.shape[0]
+    counts = np.zeros(len(candidates), dtype=np.int64)
+    for k in range(len(candidates)):
+        s = candidates[k]
+        c = 0
+        for j in range(n):
+            if j == s:
+                continue
+            if dominates(fitness[j], fitness[s]):
+                c += 1
+        counts[k] = c
+    return counts
+
+
+class SMSEMOASelector(BaseSelector):
+    """The S-Metric Selection EMOA (SMS-EMOA) environmental (Reduce) selection operator.
+
+    SMS-EMOA is a steady-state algorithm that aims explicitly at maximizing the dominated hypervolume of the
+    population. The selection (Reduce) operator combines non-dominated sorting with a hypervolume-based criterion:
+    the population is partitioned into fronts, and individuals are discarded from the worst-ranked front one at a
+    time. When discarding from the last front, the individual contributing the least exclusive hypervolume is
+    removed, which guarantees that the dominated hypervolume of the population never decreases.
+
+    Two variants are supported (see Sections 2.1 and 2.2 of the reference):
+
+    - The basic variant always removes the least-contributing individual of the worst-ranked front using the
+      contributing hypervolume.
+    - The "dominating points" (dp) variant (``use_dominating_points=True``, the default) removes, whenever the
+      population consists of more than one front, the worst-ranked individual that is dominated by the most other
+      solutions. The (more expensive) hypervolume criterion is then only used once all solutions are mutually
+      non-dominated. This variant typically achieves a comparable quality at a lower runtime.
+
+    This operator is designed to be used together with [template2][desdeo.emo.methods.templates.template2]: each
+    generation a small number of offspring is created, appended to the population, and the population is reduced
+    back to ``population_size``.
+
+    Reference:
+        Beume, N., Naujoks, B., & Emmerich, M. (2007). SMS-EMOA: Multiobjective selection based on dominated
+        hypervolume. European Journal of Operational Research, 181(3), 1653-1669.
+        https://doi.org/10.1016/j.ejor.2006.08.008
+    """
+
+    @property
+    def provided_topics(self):
+        """The topics provided by the SMS-EMOA selector."""
+        return {
+            0: [],
+            1: [SelectorMessageTopics.STATE],
+            2: [SelectorMessageTopics.SELECTED_VERBOSE_OUTPUTS, SelectorMessageTopics.SELECTED_FITNESS],
+        }
+
+    @property
+    def interested_topics(self):
+        """The topics the SMS-EMOA selector is interested in."""
+        return []
+
+    def __init__(
+        self,
+        problem: Problem,
+        verbosity: int,
+        publisher: Publisher,
+        population_size: int,
+        reference_point_offset: float = 1.0,
+        use_dominating_points: bool = True,
+        greedy_reduction: bool = True,
+        seed: int = 0,
+    ):
+        """Initialize the SMS-EMOA selection operator.
+
+        Args:
+            problem (Problem): The optimization problem to be solved.
+            verbosity (int): The verbosity level of the operator.
+            publisher (Publisher): The publisher to use for communication.
+            population_size (int): The (constant) size of the population maintained by the algorithm.
+            reference_point_offset (float, optional): The offset added to the worst objective values of the
+                worst-ranked front to build the dynamic reference point used in the hypervolume computation
+                (for problems with three or more objectives). Defaults to 1.0.
+            use_dominating_points (bool, optional): If True, use the "dominating points" variant (Algorithm 3 in
+                the reference), which is cheaper when the population is not yet fully non-dominated. Defaults to
+                True.
+            greedy_reduction (bool, optional): How to discard several individuals from the same front per
+                generation. If True (default, the faithful steady-state behaviour), individuals are removed one at
+                a time, re-evaluating hypervolume contributions after each removal. If False, the contributions are
+                computed once per front and the required number of least-contributing individuals are removed in a
+                single batch. Batching is a far cheaper approximation that is recommended for four or more
+                objectives, where the per-removal hypervolume cost would otherwise dominate the runtime. Defaults
+                to True.
+            seed (int, optional): The random seed used to break ties. Defaults to 0.
+        """
+        super().__init__(problem=problem, verbosity=verbosity, publisher=publisher, seed=seed)
+        if self.constraints_symbols is not None:
+            raise NotImplementedError(
+                "SMS-EMOA selector does not support constraints. Please use a different selector."
+            )
+        self.population_size = population_size
+        self.reference_point_offset = reference_point_offset
+        self.use_dominating_points = use_dominating_points
+        self.greedy_reduction = greedy_reduction
+        self.selection: list[int] | None = None
+        self.selected_individuals: SolutionType | None = None
+        self.selected_targets: pl.DataFrame | None = None
+        self.fitness: np.ndarray | None = None
+
+    def do(
+        self,
+        parents: tuple[SolutionType, pl.DataFrame],
+        offsprings: tuple[SolutionType, pl.DataFrame],
+    ) -> tuple[SolutionType, pl.DataFrame]:
+        """Perform the SMS-EMOA Reduce operation.
+
+        The parent and offspring populations are merged and reduced back to ``population_size`` by repeatedly
+        discarding the worst individual of the worst-ranked front.
+
+        Args:
+            parents (tuple[SolutionType, pl.DataFrame]): the decision variables as the first element.
+                The second element is the objective values, targets, and constraint violations.
+            offsprings (tuple[SolutionType, pl.DataFrame]): the decision variables as the first element.
+                The second element is the objective values, targets, and constraint violations.
+
+        Returns:
+            tuple[SolutionType, pl.DataFrame]: The selected decision variables and their objective values,
+                targets, and constraint violations.
+        """
+        if isinstance(parents[0], pl.DataFrame) and isinstance(offsprings[0], pl.DataFrame):
+            solutions = parents[0].vstack(offsprings[0])
+        elif isinstance(parents[0], list) and isinstance(offsprings[0], list):
+            solutions = parents[0] + offsprings[0]
+        else:
+            raise TypeError("The decision variables must be either a list or a polars DataFrame, not both")
+
+        alltargets = parents[1].vstack(offsprings[1])
+        targets = alltargets[self.target_symbols].to_numpy()
+        num_total = targets.shape[0]
+
+        if num_total <= self.population_size:
+            keep = np.arange(num_total)
+        else:
+            keep = self._reduce(targets, num_total - self.population_size)
+
+        self.selection = keep.tolist()
+        if isinstance(solutions, pl.DataFrame):
+            self.selected_individuals = solutions[self.selection]
+        else:
+            self.selected_individuals = [solutions[i] for i in self.selection]
+        self.selected_targets = alltargets[self.selection]
+
+        # Fitness used by the (optional) mating selection operator. Higher is better, so we use the negated
+        # non-dominated rank of the surviving individuals.
+        self.fitness = self._rank_fitness(targets[keep])
+
+        self.notify()
+        return self.selected_individuals, self.selected_targets
+
+    def _reduce(self, targets: np.ndarray, num_remove: int) -> np.ndarray:
+        """Greedily remove ``num_remove`` individuals using the SMS-EMOA Reduce criterion.
+
+        Args:
+            targets (np.ndarray): A 2D array (n x m) of objective vectors in minimization form.
+            num_remove (int): The number of individuals to discard.
+
+        Note:
+            A single non-dominated sort suffices for the whole reduction: discarding a worst-front individual
+            never promotes any surviving individual to a better front (a worst-front individual dominates nobody
+            in the population), so both the front membership of the survivors and the dominating-point counts
+            remain valid throughout. This makes a (mu + lambda) reduction much cheaper than re-sorting per removal.
+
+        Args:
+            targets (np.ndarray): A 2D array (n x m) of objective vectors in minimization form.
+            num_remove (int): The number of individuals to discard.
+
+        Returns:
+            np.ndarray: The (sorted) indices of the surviving individuals.
+        """
+        fronts = fast_non_dominated_sort(targets)
+        num_fronts = len(fronts)
+        alive = np.ones(targets.shape[0], dtype=bool)
+        remaining = num_remove
+
+        # Process fronts from worst to best. ``front_id == 0`` is the only/first (non-dominated) front.
+        for front_id in range(num_fronts - 1, -1, -1):
+            if remaining == 0:
+                break
+            front = np.where(fronts[front_id])[0]
+            if self.use_dominating_points and front_id > 0:
+                # Dominating points variant: discard the solutions dominated by the most others first. The counts
+                # are stable across removals, so they are computed once and the worst are taken in order.
+                dom_counts = _count_dominating_points(targets, front)
+                order = front[np.argsort(-dom_counts, kind="stable")]
+                take = min(remaining, len(order))
+                alive[order[:take]] = False
+                remaining -= take
+            elif self.greedy_reduction:
+                # Hypervolume criterion on the worst front: remove the least contributor, re-evaluating after each
+                # removal because exclusive contributions depend on the surviving neighbours.
+                survivors = list(front)
+                while remaining > 0 and len(survivors) > 0:
+                    victim = self._least_contributor(targets[survivors])
+                    alive[survivors.pop(victim)] = False
+                    remaining -= 1
+            else:
+                # Batched approximation: compute contributions once and drop the required number of least
+                # contributors together. Much cheaper for many objectives at a small quality cost.
+                take = min(remaining, len(front))
+                contributions = self._contributions(targets[front])
+                order = np.argsort(contributions, kind="stable")
+                alive[front[order[:take]]] = False
+                remaining -= take
+        return np.where(alive)[0]
+
+    def _contributions(self, front: np.ndarray) -> np.ndarray:
+        """Return the exclusive hypervolume contribution of every solution of a non-dominated front."""
+        if front.shape[0] <= 1:
+            return np.zeros(front.shape[0])
+        if front.shape[1] == _BIOBJECTIVE:
+            return _hv_contributions_2d(front)
+        reference_point = front.max(axis=0) + self.reference_point_offset
+        return np.asarray(moocore.hv_contributions(front, ref=reference_point))
+
+    def _least_contributor(self, front: np.ndarray) -> int:
+        """Return the index (into ``front``) of the least contributing solution of a non-dominated front."""
+        if front.shape[0] <= 1:
+            return 0
+        return int(self._argmin_random_tie(self._contributions(front)))
+
+    def _argmin_random_tie(self, values: np.ndarray) -> int:
+        """Return the index of the minimum value, breaking ties uniformly at random."""
+        candidates = np.where(values == values.min())[0]
+        if len(candidates) == 1:
+            return int(candidates[0])
+        return int(candidates[self.rng.integers(0, len(candidates))])
+
+    @staticmethod
+    def _rank_fitness(targets: np.ndarray) -> np.ndarray:
+        """Compute a scalar fitness (higher is better) as the negated non-dominated rank."""
+        fronts = fast_non_dominated_sort(targets)
+        fitness = np.zeros(targets.shape[0])
+        for rank in range(len(fronts)):
+            fitness[fronts[rank]] = -rank
+        return fitness
+
+    def state(self) -> Sequence[Message]:
+        """Return the state of the SMS-EMOA selector."""
+        if self.verbosity == 0 or self.selection is None or self.selected_targets is None:
+            return []
+        if self.verbosity == 1:
+            return [
+                DictMessage(
+                    topic=SelectorMessageTopics.STATE,
+                    value={
+                        "population_size": self.population_size,
+                        "selected_individuals": self.selection,
+                    },
+                    source=self.__class__.__name__,
+                )
+            ]
+        # verbosity == 2
+        if isinstance(self.selected_individuals, pl.DataFrame):
+            message = PolarsDataFrameMessage(
+                topic=SelectorMessageTopics.SELECTED_VERBOSE_OUTPUTS,
+                value=pl.concat([self.selected_individuals, self.selected_targets], how="horizontal"),
+                source=self.__class__.__name__,
+            )
+        else:
+            warnings.warn("Population is not a Polars DataFrame. Defaulting to providing OUTPUTS only.", stacklevel=2)
+            message = PolarsDataFrameMessage(
+                topic=SelectorMessageTopics.SELECTED_VERBOSE_OUTPUTS,
+                value=self.selected_targets,
+                source=self.__class__.__name__,
+            )
+        return [
+            DictMessage(
+                topic=SelectorMessageTopics.STATE,
+                value={
+                    "population_size": self.population_size,
+                    "selected_individuals": self.selection,
+                },
+                source=self.__class__.__name__,
+            ),
+            message,
+            NumpyArrayMessage(
+                topic=SelectorMessageTopics.SELECTED_FITNESS,
+                value=self.fitness,
+                source=self.__class__.__name__,
+            ),
+        ]
+
+    def update(self, message: Message) -> None:
+        """The SMS-EMOA selector does not react to messages."""

--- a/desdeo/emo/options/algorithms.py
+++ b/desdeo/emo/options/algorithms.py
@@ -1,8 +1,5 @@
 """Define popular MOEAs as Pydantic models."""
 
-from collections.abc import Callable
-from functools import partial
-
 from desdeo.emo.options.crossover import SimulatedBinaryCrossoverOptions, UniformMixedIntegerCrossoverOptions
 from desdeo.emo.options.generator import LHSGeneratorOptions, RandomMixedIntegerGeneratorOptions
 from desdeo.emo.options.mutation import BoundedPolynomialMutationOptions, MixedIntegerRandomMutationOptions
@@ -15,17 +12,14 @@ from desdeo.emo.options.selection import (
     ParameterAdaptationStrategy,
     ReferenceVectorOptions,
     RVEASelectorOptions,
+    SMSEMOASelectorOptions,
 )
 from desdeo.emo.options.templates import (
-    ConstructorExtras,
     EMOOptions,
-    EMOResult,
     Template1Options,
     Template2Options,
-    emo_constructor,
 )
-from desdeo.emo.options.termination import MaxGenerationsTerminatorOptions
-from desdeo.problem import Problem
+from desdeo.emo.options.termination import MaxEvaluationsTerminatorOptions, MaxGenerationsTerminatorOptions
 
 
 def rvea_options() -> EMOOptions:
@@ -259,6 +253,90 @@ def nsga2_options() -> EMOOptions:
     )
 
 
+def smsemoa_options(
+    population_size: int = 100,
+    n_offspring: int = 100,
+    max_evaluations: int = 20000,
+    use_dominating_points: bool = True,
+    greedy_reduction: bool = True,
+    seed: int = 42,
+) -> EMOOptions:
+    """Get default S-Metric Selection EMOA (SMS-EMOA) options as a Pydantic model.
+
+    SMS-EMOA is a steady-state evolutionary multiobjective algorithm whose selection (Reduce) operator combines
+    non-dominated sorting with the contributing hypervolume, thereby steering the population towards a
+    well-distributed approximation of the Pareto front that maximizes the dominated hypervolume. This
+    implementation creates ``n_offspring`` offspring per generation (a (mu + n_offspring) scheme) and reduces the
+    population back to ``population_size`` by repeatedly discarding the worst individual of the worst-ranked
+    front. Termination is based on the number of function evaluations.
+
+    Reference:
+        Beume, N., Naujoks, B., & Emmerich, M. (2007). SMS-EMOA: Multiobjective selection based on dominated
+        hypervolume. European Journal of Operational Research, 181(3), 1653-1669.
+        https://doi.org/10.1016/j.ejor.2006.08.008
+
+    Args:
+        population_size (int, optional): The (constant) size of the population. Defaults to 100.
+        n_offspring (int, optional): The number of offspring generated each generation. Must be greater than 1.
+            Smaller values are closer to the original steady-state SMS-EMOA (one offspring per generation) and give
+            marginally higher quality, while larger values amortize per-iteration overhead and run faster. The
+            default of 100 (a (mu + mu) scheme) is a good balance. Defaults to 100.
+        max_evaluations (int, optional): The function evaluation budget. Defaults to 20000.
+        use_dominating_points (bool, optional): Whether to use the cheaper "dominating points" variant when the
+            population is not yet fully non-dominated. Defaults to True.
+        greedy_reduction (bool, optional): If True, remove individuals one at a time, recomputing hypervolume
+            contributions after each removal (faithful, best quality). If False, remove the least contributors in a
+            single batch per generation, which is dramatically faster for four or more objectives at a small
+            quality cost. Defaults to True.
+        seed (int, optional): The random seed. Defaults to 42.
+
+    Returns:
+        EMOOptions: The default SMS-EMOA options as a Pydantic model.
+    """
+    return EMOOptions(
+        preference=None,
+        template=Template2Options(
+            algorithm_name="SMS-EMOA",
+            crossover=SimulatedBinaryCrossoverOptions(
+                name="SimulatedBinaryCrossover",
+                xover_distribution=15,
+                xover_probability=0.9,
+            ),
+            mutation=BoundedPolynomialMutationOptions(
+                name="BoundedPolynomialMutation",
+                distribution_index=20,
+                mutation_probability=None,
+            ),
+            selection=SMSEMOASelectorOptions(
+                name="SMSEMOASelector",
+                population_size=population_size,
+                reference_point_offset=1.0,
+                use_dominating_points=use_dominating_points,
+                greedy_reduction=greedy_reduction,
+            ),
+            mate_selection=TournamentSelectionOptions(
+                name="TournamentSelection",
+                tournament_size=2,
+                winner_size=n_offspring,
+            ),
+            generator=LHSGeneratorOptions(
+                name="LHSGenerator",
+                n_points=population_size,
+            ),
+            repair=NoRepairOptions(
+                name="NoRepair",
+            ),
+            termination=MaxEvaluationsTerminatorOptions(
+                name="MaxEvaluationsTerminator",
+                max_evaluations=max_evaluations,
+            ),
+            use_archive=True,
+            verbosity=2,
+            seed=seed,
+        ),
+    )
+
+
 def rvea_mixed_integer_options() -> EMOOptions:
     """Get default RVEA options for mixed integer problems as a Pydantic model.
 
@@ -414,11 +492,12 @@ if __name__ == "__main__":
     json_dump_path = current_dir.parent.parent.parent.parent / "datasets" / "emoTemplates"
 
     for algo_name, algo in zip(
-        ["rvea", "nsga3", "ibea", "rvea_mixed_integer", "nsga3_mixed_integer", "ibea_mixed_integer"],
+        ["rvea", "nsga3", "ibea", "smsemoa", "rvea_mixed_integer", "nsga3_mixed_integer", "ibea_mixed_integer"],
         [
             rvea_options,
             nsga3_options,
             ibea_options,
+            smsemoa_options,
             rvea_mixed_integer_options,
             nsga3_mixed_integer_options,
             ibea_mixed_integer_options,

--- a/desdeo/emo/options/selection.py
+++ b/desdeo/emo/options/selection.py
@@ -14,6 +14,7 @@ from desdeo.emo.operators.selection import (
     ParameterAdaptationStrategy,
     ReferenceVectorOptions,
     RVEASelector,
+    SMSEMOASelector,
 )
 from desdeo.tools.indicators_binary import self_epsilon, self_hv
 
@@ -86,7 +87,46 @@ class IBEASelectorOptions(BaseModel):
     """The binary indicator for IBEA."""
 
 
-SelectorOptions = RVEASelectorOptions | NSGA2SelectorOptions | NSGA3SelectorOptions | IBEASelectorOptions
+class SMSEMOASelectorOptions(BaseModel):
+    """Options for SMS-EMOA Selection."""
+
+    name: Literal["SMSEMOASelector"] = Field(
+        default="SMSEMOASelector", frozen=True, description="The name of the selection operator."
+    )
+    """The name of the selection operator."""
+    population_size: int = Field(gt=0, description="The population size.")
+    """The population size."""
+    reference_point_offset: float = Field(
+        default=1.0,
+        gt=0.0,
+        description=(
+            "The offset added to the worst objective values of the worst-ranked front to build the dynamic "
+            "reference point used in the hypervolume computation (for three or more objectives)."
+        ),
+    )
+    """The offset for the dynamic reference point used in the hypervolume computation."""
+    use_dominating_points: bool = Field(
+        default=True,
+        description=(
+            "Whether to use the cheaper 'dominating points' variant when the population is not yet fully "
+            "non-dominated (Algorithm 3 in the SMS-EMOA reference)."
+        ),
+    )
+    """Whether to use the 'dominating points' variant for dominated solutions."""
+    greedy_reduction: bool = Field(
+        default=True,
+        description=(
+            "If True, discard individuals one at a time, recomputing hypervolume contributions after each removal "
+            "(faithful, best quality). If False, remove the required number of least-contributing individuals in a "
+            "single batch per front, which is much faster for four or more objectives at a small quality cost."
+        ),
+    )
+    """Whether to remove individuals one at a time (greedy) or in a single batch per front."""
+
+
+SelectorOptions = (
+    RVEASelectorOptions | NSGA2SelectorOptions | NSGA3SelectorOptions | IBEASelectorOptions | SMSEMOASelectorOptions
+)
 
 
 def selection_constructor(
@@ -112,6 +152,7 @@ def selection_constructor(
         "NSGA2Selector": NSGA2Selector,
         "NSGA3Selector": NSGA3Selector,
         "IBEASelector": IBEASelector,
+        "SMSEMOASelector": SMSEMOASelector,
     }
     options: dict = options.model_dump()
     name = options.pop("name")

--- a/tests/test_smsemoa.py
+++ b/tests/test_smsemoa.py
@@ -1,0 +1,205 @@
+"""Tests for the SMS-EMOA algorithm and its hypervolume-based selection operator."""
+
+import moocore
+import numpy as np
+import pytest
+
+from desdeo.emo.operators.selection import (
+    SMSEMOASelector,
+    _count_dominating_points,
+    _hv_contributions_2d,
+)
+from desdeo.emo.options.algorithms import smsemoa_options
+from desdeo.emo.options.templates import emo_constructor
+from desdeo.problem.testproblems import dtlz2, re22, zdt1, zdt2
+from desdeo.tools.non_dominated_sorting import non_dominated
+from desdeo.tools.patterns import Publisher
+
+
+def _make_selector(problem, population_size, use_dominating_points=True, greedy_reduction=True):
+    """Build an SMS-EMOA selector for unit testing (verbosity 0 to avoid needing other components)."""
+    return SMSEMOASelector(
+        problem=problem,
+        verbosity=0,
+        publisher=Publisher(),
+        population_size=population_size,
+        use_dominating_points=use_dominating_points,
+        greedy_reduction=greedy_reduction,
+    )
+
+
+def test_hv_contributions_2d_known_values():
+    """The 2D contribution formula matches the exact values and keeps the two boundary points."""
+    # A non-dominated bi-objective front (minimization).
+    front = np.array([[0.0, 3.0], [1.0, 2.0], [2.0, 1.0], [3.0, 0.0]])
+    contrib = _hv_contributions_2d(front)
+    # Boundary points have infinite contribution and are therefore never removed.
+    assert np.isinf(contrib[0])
+    assert np.isinf(contrib[3])
+    # Interior contributions: (f1_next - f1_i) * (f2_prev - f2_i).
+    assert contrib[1] == pytest.approx((2.0 - 1.0) * (3.0 - 2.0))
+    assert contrib[2] == pytest.approx((3.0 - 2.0) * (2.0 - 1.0))
+
+
+def test_hv_contributions_2d_small_front():
+    """Fronts with two or fewer points are all boundary points (kept)."""
+    assert np.all(np.isinf(_hv_contributions_2d(np.array([[0.0, 1.0], [1.0, 0.0]]))))
+    assert np.all(np.isinf(_hv_contributions_2d(np.array([[0.0, 1.0]]))))
+
+
+def test_hv_contributions_2d_least_in_middle():
+    """A point in a dense region contributes the least and is the removal candidate."""
+    # Two points are clustered close together around f1 ~1.0; one of them should contribute the least.
+    front = np.array([[0.0, 3.0], [0.9, 1.1], [1.0, 1.0], [3.0, 0.0]])
+    contrib = _hv_contributions_2d(front)
+    assert int(np.argmin(contrib)) in (1, 2)
+
+
+def test_count_dominating_points():
+    """The dominating-points count matches manual counting."""
+    # Point 0 dominates 1, 2, 3. Point 1 dominates 3. Points are in minimization form.
+    fitness = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.5], [3.0, 3.0]])
+    candidates = np.array([1, 2, 3])
+    counts = _count_dominating_points(fitness, candidates)
+    # 1 is dominated by {0}; 2 is dominated by {0}; 3 is dominated by {0, 1, 2}.
+    assert counts.tolist() == [1, 1, 3]
+
+
+def test_reduce_keeps_population_size_and_boundaries():
+    """The reduce step returns exactly ``population_size`` survivors and keeps 2D boundary solutions."""
+    problem = zdt1(number_of_variables=10)
+    selector = _make_selector(problem, population_size=4)
+    # 6 mutually non-dominated points; the two extremes must always survive.
+    targets = np.array([[0.0, 5.0], [1.0, 4.0], [2.0, 3.0], [3.0, 2.0], [4.0, 1.0], [5.0, 0.0]])
+    survivors = selector._reduce(targets, num_remove=2)
+    assert len(survivors) == 4
+    assert 0 in survivors  # extreme (best f1)
+    assert 5 in survivors  # extreme (best f2)
+
+
+def test_reduce_hypervolume_non_decreasing():
+    """Reducing a population never decreases its dominated hypervolume (the SMS-EMOA invariant)."""
+    problem = zdt1(number_of_variables=10)
+    selector = _make_selector(problem, population_size=9, use_dominating_points=False)
+    # A dense, mutually non-dominated front on a concave (quarter-circle) curve.
+    theta = np.linspace(0.0, np.pi / 2, 12)
+    targets = np.column_stack([1 - np.cos(theta), 1 - np.sin(theta)])
+    ref = np.array([1.1, 1.1])
+    hv_before = moocore.hypervolume(targets, ref=ref)
+    survivors = selector._reduce(targets, num_remove=3)
+    hv_after = moocore.hypervolume(targets[survivors], ref=ref)
+    assert len(survivors) == 9
+    # Removing the least-contributing points keeps the hypervolume as high as possible: it can only
+    # shrink slightly (we removed interior points from a dense front, keeping the boundaries).
+    assert hv_after <= hv_before + 1e-12
+    assert hv_after > 0.97 * hv_before
+    # Both extremes of the front survive.
+    assert 0 in survivors
+    assert 11 in survivors
+
+
+def test_batch_reduce_keeps_size_and_boundaries():
+    """The batched reduction returns exactly ``population_size`` survivors and keeps 2D boundary solutions."""
+    problem = zdt1(number_of_variables=10)
+    selector = _make_selector(problem, population_size=6, greedy_reduction=False)
+    # A dense, mutually non-dominated front; the two extremes (infinite contribution) must survive.
+    theta = np.linspace(0.0, np.pi / 2, 12)
+    targets = np.column_stack([1 - np.cos(theta), 1 - np.sin(theta)])
+    survivors = selector._reduce(targets, num_remove=6)
+    assert len(survivors) == 6
+    assert 0 in survivors
+    assert 11 in survivors
+
+
+def test_batch_reduce_preserves_most_hypervolume():
+    """Batched removal keeps most of the dominated hypervolume (cheaper approximation of the greedy rule)."""
+    problem = dtlz2(n_variables=7, n_objectives=3)
+    selector = _make_selector(problem, population_size=20, use_dominating_points=False, greedy_reduction=False)
+    rng = np.random.default_rng(0)
+    # A non-dominated cloud on the positive octant of a sphere (3 objectives, minimization).
+    pts = np.abs(rng.normal(size=(40, 3)))
+    pts /= np.linalg.norm(pts, axis=1, keepdims=True)
+    pts = pts[non_dominated(pts)]
+    ref = np.full(3, 1.1)
+    hv_before = moocore.hypervolume(pts, ref=ref)
+    keep = max(1, len(pts) - 5)
+    survivors = selector._reduce(pts, num_remove=len(pts) - keep)
+    assert len(survivors) == keep
+    hv_after = moocore.hypervolume(pts[survivors], ref=ref)
+    assert hv_after > 0.9 * hv_before
+
+
+def test_reduce_removes_dominated_first():
+    """When a clearly dominated solution is present, it is discarded before non-dominated ones."""
+    problem = zdt1(number_of_variables=10)
+    selector = _make_selector(problem, population_size=3, use_dominating_points=True)
+    targets = np.array([[0.0, 2.0], [1.0, 1.0], [2.0, 0.0], [3.0, 3.0]])  # last point is dominated by all
+    survivors = selector._reduce(targets, num_remove=1)
+    assert 3 not in survivors
+    assert sorted(survivors.tolist()) == [0, 1, 2]
+
+
+@pytest.mark.ea
+def test_smsemoa_zdt1():
+    """SMS-EMOA converges to and spreads along the ZDT1 Pareto front."""
+    problem = zdt1(number_of_variables=30)
+    opts = smsemoa_options(population_size=100, n_offspring=20, max_evaluations=15000, seed=1)
+    solver, _ = emo_constructor(opts, problem)
+    res = solver()
+    out = res.optimal_outputs
+    assert len(out) == 100
+    # ZDT1 Pareto front: f2 = 1 - sqrt(f1), f1 in [0, 1]. Convergence => f2 close to the front.
+    f1 = out["f_1"].to_numpy()
+    f2 = out["f_2"].to_numpy()
+    front_f2 = 1 - np.sqrt(np.clip(f1, 0, 1))
+    assert np.median(f2 - front_f2) < 0.02  # close to the true front
+    assert f1.max() - f1.min() > 0.8  # well spread along the front
+
+
+@pytest.mark.ea
+def test_smsemoa_zdt2_basic_variant():
+    """The basic (pure hypervolume) variant also converges on the concave ZDT2 front."""
+    problem = zdt2(n_variables=30)
+    opts = smsemoa_options(
+        population_size=100, n_offspring=20, max_evaluations=15000, use_dominating_points=False, seed=1
+    )
+    solver, _ = emo_constructor(opts, problem)
+    res = solver()
+    out = res.optimal_outputs
+    f1 = out["f_1"].to_numpy()
+    f2 = out["f_2"].to_numpy()
+    front_f2 = 1 - np.clip(f1, 0, 1) ** 2
+    assert np.median(f2 - front_f2) < 0.02
+    assert f1.max() - f1.min() > 0.8
+
+
+@pytest.mark.ea
+def test_smsemoa_dtlz2():
+    """SMS-EMOA places solutions on the DTLZ2 unit-sphere Pareto front (three objectives)."""
+    problem = dtlz2(n_variables=12, n_objectives=3)
+    opts = smsemoa_options(population_size=100, n_offspring=20, max_evaluations=20000, seed=1)
+    solver, _ = emo_constructor(opts, problem)
+    res = solver()
+    out = res.optimal_outputs
+    norm = (out["f_1"] ** 2 + out["f_2"] ** 2 + out["f_3"] ** 2).sqrt()
+    # Most solutions should lie on the unit sphere (norm ~1).
+    assert norm.median() < 1.05
+
+
+@pytest.mark.ea
+def test_smsemoa_batch_reduction_end_to_end():
+    """The fast batched-reduction variant still converges to the DTLZ2 unit-sphere front."""
+    problem = dtlz2(n_variables=12, n_objectives=3)
+    opts = smsemoa_options(population_size=100, n_offspring=100, max_evaluations=15000, greedy_reduction=False, seed=1)
+    solver, _ = emo_constructor(opts, problem)
+    res = solver()
+    out = res.optimal_outputs
+    norm = (out["f_1"] ** 2 + out["f_2"] ** 2 + out["f_3"] ** 2).sqrt()
+    assert norm.median() < 1.1
+
+
+@pytest.mark.ea
+def test_smsemoa_constraints_not_supported():
+    """The selector clearly rejects constrained problems (not yet supported)."""
+    with pytest.raises(NotImplementedError):
+        _make_selector(re22(), population_size=10)


### PR DESCRIPTION
- Implement SMS-EMOA: add SMSEMOASelector with hypervolume-based environmental selection (non-dominated sorting + contributing hypervolume), a dynamic reference point, an exact jitted 2D contribution formula, moocore-based contributions for three or more objectives, and the optional "dominating points" variant.
- Add greedy vs batched reduction (greedy_reduction flag): greedy removes one individual at a time (faithful, best quality), batched computes contributions once per generation for a large speedup at four or more objectives at a small quality cost.
- Wire SMS-EMOA through the options layer: SMSEMOASelectorOptions plus selection_constructor registration, and a smsemoa_options() factory reusing template2 with tournament mate selection and an evaluation-budget terminator.
- Fix desdeo.emo package import: import emo_constructor from options.templates (its real source) instead of relying on a re-export from options.algorithms, and surface smsemoa_options alongside the other algorithm factories.
- Add unit tests covering the contribution helpers, the reduce invariants, both reduction modes, and end-to-end convergence.