### PR TITLE
Remove broken and malicious script

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,5 +157,4 @@ extra_css:
 extra_javascript:
   - extrajs/extra.js
   - extrajs/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
Removed a script that was causing the annoying fake login prompt to trigger on the desdeo docs website.

[https://www.kaspersky.com/blog/polyfill-io-service-supply-chain-attacks/51635/](https://www.kaspersky.com/blog/polyfill-io-service-supply-chain-attacks/51635/)

<img width="514" height="395" alt="image" src="https://github.com/user-attachments/assets/7cb6f461-ca01-4ab2-be66-4bb8cab730aa" />