### PR TITLE
No more warnings when building docs and fixed some ruff complaints.

### DIFF
--- a/desdeo/problem/cvxpy_evaluator.py
+++ b/desdeo/problem/cvxpy_evaluator.py
@@ -435,11 +435,11 @@ class CVXPYEvaluator:
         self.objective_expr = objective
         self.problem_model = cp.Problem(objective, list(self.constraints.values()))
 
-    def solve(self, **kwargs):
+    def solve(self, **kwargs: dict[str, any]):
         """Solve the CVXPY problem.
 
         Args:
-            **kwargs: additional arguments to pass to cp.Problem.solve().
+            **kwargs (dict[str, any]): additional arguments to pass to cp.Problem.solve().
         """
         if self.problem_model is None:
             msg = "No optimization target has been set. Call set_optimization_target() first."

--- a/desdeo/problem/gurobipy_evaluator.py
+++ b/desdeo/problem/gurobipy_evaluator.py
@@ -267,7 +267,7 @@ class GurobipyEvaluator:
 
         return objective_functions
 
-    def init_constraints(self, problem: Problem) -> gp.Model:
+    def init_constraints(self, problem: Problem, model: gp.Model) -> gp.Model:
         """Add constraint expressions to a Gurobipy Model.
 
         Args:
@@ -581,7 +581,7 @@ class GurobipyEvaluator:
 
         Args:
             target (str): an str representing a symbol. Needs to match an objective function or scalarization
-            function already found in the model.
+                function already found in the model.
             maximize (bool): If true, the target function is maximized instead of minimized
 
         Raises:

--- a/desdeo/problem/gurobipy_evaluator.py
+++ b/desdeo/problem/gurobipy_evaluator.py
@@ -267,12 +267,12 @@ class GurobipyEvaluator:
 
         return objective_functions
 
-    def init_constraints(self, problem: Problem, model: gp.Model) -> gp.Model:
+    def init_constraints(self, problem: Problem, model: gp.Model | None = None) -> gp.Model:
         """Add constraint expressions to a Gurobipy Model.
 
         Args:
             problem (Problem): the problem from which to extract the constraint function expressions.
-            model (GurobipyModel): the GurobipyModel to add the exprssions to.
+            model (GurobipyModel | None): the GurobipyModel to add the expressions to.
 
         Raises:
             GurobipyEvaluatorError: when an unsupported constraint type is encountered.

--- a/desdeo/problem/scenario.py
+++ b/desdeo/problem/scenario.py
@@ -229,7 +229,9 @@ class ScenarioModel(BaseModel):
                     )
         return v
 
-    def with_base_problem(self, problem: "Problem | None" = None, validate: bool = False, **updates) -> "ScenarioModel":
+    def with_base_problem(
+        self, problem: "Problem | None" = None, validate: bool = False, **updates: dict[str, any]
+    ) -> "ScenarioModel":
         """Return a new ScenarioModel with the base_problem updated.
 
         By default uses model_copy, so validators are NOT re-run. Pass

--- a/desdeo/tools/generateReferencePoints.py
+++ b/desdeo/tools/generateReferencePoints.py
@@ -30,15 +30,14 @@ def householder(vector):
     v = vector[np.newaxis]
     denominator = np.matmul(v, v.T)
     numerator = np.matmul(v.T, v)
-    rot_mat = identity_mat - (2 * numerator / denominator)
-    return rot_mat
+    return identity_mat - (2 * numerator / denominator)
 
 
 def rotate(initial_vector, rotated_vector, other_vectors):
     """Calculate the rotation matrix that rotates the initial_vector to the
     rotated_vector. Apply that rotation on other_vectors and return.
-    Uses Householder reflections twice to achieve this."""
-
+    Uses Householder reflections twice to achieve this.
+    """
     init_vec_norm = normalize(initial_vector)
     rot_vec_norm = normalize(np.asarray(rotated_vector))
     middle_vec_norm = normalize(init_vec_norm + rot_vec_norm)
@@ -47,11 +46,10 @@ def rotate(initial_vector, rotated_vector, other_vectors):
     Q1 = householder(first_reflector)
     Q2 = householder(second_reflector)
     reflection_matrix = np.matmul(Q2, Q1)
-    rotated_vectors = np.matmul(other_vectors, np.transpose(reflection_matrix))
-    return rotated_vectors
+    return np.matmul(other_vectors, np.transpose(reflection_matrix))
 
 
-def get_reference_hull(num_dims):
+def get_reference_hull(num_dims) -> tuple[np.ndarray, np.ndarray, np.ndarray, ConvexHull]:
     """Get the convex hull of the valid reference points for IPA.
 
     This algorithm generates the vertices of the unit hypercube in the (num_dims)-dimensional space.
@@ -101,8 +99,7 @@ def rotate_in(vertices: np.ndarray) -> np.ndarray:
     """
     num_dims = len(vertices[0])
     rotated_vertices = rotate([1] * num_dims, ([0] * (num_dims - 1) + [1]), vertices)
-    rotated_vertices = rotated_vertices[:, :-1]
-    return rotated_vertices
+    return rotated_vertices[:, :-1]
 
 
 def rotate_out(points: np.ndarray) -> np.ndarray:
@@ -115,12 +112,11 @@ def rotate_out(points: np.ndarray) -> np.ndarray:
         np.ndarray: The projected points.
     """
     points = np.atleast_2d(points)
-    num_points, num_dims = points.shape
+    num_dims = points.shape[1]
     points_rotated = np.hstack((points, np.ones((len(points), 1))))
     points_rotated = rotate(([0] * (num_dims) + [1]), [1] * (num_dims + 1), points_rotated)
     # Move (along nadir-ideal direction) the plane of these points such that it passes through nadir
-    points_rotated = points_rotated + 1 - 1 / np.sqrt(num_dims + 1)
-    return points_rotated
+    return points_rotated + 1 - 1 / np.sqrt(num_dims + 1)
 
 
 def get_hull_equations(hull: ConvexHull) -> tuple[np.ndarray, np.ndarray]:
@@ -196,7 +192,7 @@ def numba_random_gen(num_points: int, bounding_box: np.ndarray, A: np.ndarray, b
         point = np.zeros(num_dims_)
         for i in range(num_dims_):
             # Generate a random point within the bounding box
-            point[i] = np.random.uniform(bounding_box[0, i], bounding_box[1, i])
+            point[i] = np.random.Generator.uniform(bounding_box[0, i], bounding_box[1, i])
         if np.all(point @ A + b < eps):
             # If the point is inside the convex hull, add it to the list of points
             points[counter] = point

--- a/desdeo/tools/group_scalarization.py
+++ b/desdeo/tools/group_scalarization.py
@@ -52,7 +52,7 @@ def add_group_asf(
         problem (Problem): the problem to which the scalarization function should be added.
         symbol (str): the symbol to reference the added scalarization function.
         reference_points (list[dict[str, float]]): a list of reference points as objective dicts.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
         nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
@@ -178,7 +178,8 @@ def add_group_asf_agg(
     Args:
         problem (Problem): the problem to which the scalarization function should be added.
         symbol (str): the symbol to reference the added scalarization function.
-        reference_points (list[dict[str, float]]): a list of reference points as objective dicts.
+        agg_aspirations (dict[str, float]): a dictionary of aggregated aspiration levels (min aspirations).
+        agg_bounds (dict[str, float]): a dictionary of aggregated bounds (max bounds).
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
         nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
@@ -299,7 +300,7 @@ def add_group_asf_diff(
         problem (Problem): the problem to which the scalarization function should be added.
         symbol (str): the symbol to reference the added scalarization function.
         reference_points (list[dict[str, float]]): a list of reference points as objective dicts.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
         nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
@@ -454,8 +455,8 @@ def add_group_asf_agg_diff(
     Args:
         problem (Problem): the problem to which the scalarization function should be added.
         symbol (str): the symbol to reference the added scalarization function.
-        reference_points (list[dict[str, float]]): a list of reference points as objective dicts.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_aspirations (dict[str, float]): a dictionary of aggregated aspiration levels (min aspirations).
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
         nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
@@ -580,7 +581,7 @@ def add_group_asf_agg_diff(
     return _problem.add_constraints(constraints), symbol
 
 
-def add_group_nimbus(  # noqa: PLR0913
+def add_group_nimbus(
     problem: Problem,
     symbol: str,
     classifications_list: list[dict[str, tuple[str, float | None]]],
@@ -641,7 +642,7 @@ def add_group_nimbus(  # noqa: PLR0913
         current_objective_vector (dict[str, float]): the current objective vector that corresponds to
             a Pareto optimal solution. The classifications are assumed to been given in respect to
             this vector.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
         nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
@@ -706,8 +707,6 @@ def add_group_nimbus(  # noqa: PLR0913
     max_args = []
     constraints = []
 
-    print(classifications_list)
-
     for i in range(len(classifications_list)):
         classifications = classifications_list[i]
         for obj in problem.objectives:
@@ -752,7 +751,7 @@ def add_group_nimbus(  # noqa: PLR0913
                     # not relevant for this group scalarization
                     pass
 
-                case (">=", reservation):
+                case ">=":
                     con_expr = f"{_symbol}_min - {bounds[_symbol]} "
                     constraints.append(
                         Constraint(
@@ -796,7 +795,7 @@ def add_group_nimbus(  # noqa: PLR0913
     return _problem.add_constraints(constraints), symbol
 
 
-def add_group_nimbus_compromise(  # noqa: PLR0913
+def add_group_nimbus_compromise(
     problem: Problem,
     symbol: str,
     group_classification: dict[str, tuple[Literal["improve", "worsen", "conflict"], list[float]]],
@@ -955,8 +954,6 @@ def add_group_nimbus_compromise(  # noqa: PLR0913
     # max term and constraints
     max_args = []
     constraints = []
-
-    print(group_classification)
 
     # Derive the group classifications
 
@@ -1037,7 +1034,8 @@ def add_group_nimbus_compromise(  # noqa: PLR0913
                     )
             case _:
                 msg = (
-                    f"Warning! The classification {group_classification[_symbol]} was supplied, but it is not supported."
+                    f"Warning! The classification {group_classification[_symbol]} was "
+                    "supplied, but it is not supported. "
                     "Must be one of ['improve', 'worsen', 'conflict']"
                 )
     max_expr = f"Max({','.join(max_args)})"
@@ -1059,7 +1057,7 @@ def add_group_nimbus_compromise(  # noqa: PLR0913
     return _problem.add_constraints(constraints), symbol
 
 
-def add_group_nimbus_compromise_diff(  # noqa: PLR0913
+def add_group_nimbus_compromise_diff(
     problem: Problem,
     symbol: str,
     group_classification: dict[str, tuple[Literal["improve", "worsen", "conflict"], list[float]]],
@@ -1217,8 +1215,6 @@ def add_group_nimbus_compromise_diff(  # noqa: PLR0913
 
     # max term and constraints
     constraints = []
-
-    print(group_classification)
 
     # define the auxiliary variable
     alpha = Variable(
@@ -1329,7 +1325,8 @@ def add_group_nimbus_compromise_diff(  # noqa: PLR0913
                     )
             case _:
                 msg = (
-                    f"Warning! The classification {group_classification[_symbol]} was supplied, but it is not supported."
+                    f"Warning! The classification {group_classification[_symbol]} was "
+                    "supplied, but it is not supported."
                     "Must be one of ['improve', 'worsen', 'conflict']"
                 )
 
@@ -1351,7 +1348,7 @@ def add_group_nimbus_compromise_diff(  # noqa: PLR0913
     return _problem.add_constraints(constraints), symbol
 
 
-def add_group_nimbus_sf(  # noqa: PLR0913
+def add_group_nimbus_sf(
     problem: Problem,
     symbol: str,
     classifications_list: list[dict[str, tuple[str, float | None]]],
@@ -1361,7 +1358,8 @@ def add_group_nimbus_sf(  # noqa: PLR0913
     delta: float = 0.000001,
     rho: float = 0.000001,
 ) -> tuple[Problem, str]:
-    r"""Implements the multiple decision maker variant of the NIMBUS scalarization function. Variant without aggregated bounds.
+    r"""Implements the multiple decision maker variant of the NIMBUS scalarization function.
+        Variant without aggregated bounds.
 
     The scalarization function is defined as follows:
 
@@ -1576,7 +1574,7 @@ def add_group_nimbus_sf(  # noqa: PLR0913
     return _problem.add_constraints(constraints), symbol
 
 
-def add_group_nimbus_diff(  # noqa: PLR0913
+def add_group_nimbus_diff(
     problem: Problem,
     symbol: str,
     classifications_list: list[dict[str, tuple[str, float | None]]],
@@ -1641,7 +1639,7 @@ def add_group_nimbus_diff(  # noqa: PLR0913
         current_objective_vector (dict[str, float]): the current objective vector that corresponds to
             a Pareto optimal solution. The classifications are assumed to been given in respect to
             this vector.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
         nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
@@ -1776,7 +1774,7 @@ def add_group_nimbus_diff(  # noqa: PLR0913
                 case ("=", _):
                     # not relevant for this group scalarization
                     pass
-                case (">=", reservation):
+                case ">=":
                     con_expr = f"{_symbol}_min - {bounds[_symbol]}"
                     constraints.append(
                         Constraint(
@@ -1846,7 +1844,7 @@ def add_group_stom(
         reference_points (list[dict[str, float]]): a list of dicts with keys corresponding to objective
             function symbols and values to reference point components, i.e.,
             aspiration levels.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
         rho (float, optional): a small scalar value to scale the sum in the objective
@@ -1973,10 +1971,8 @@ def add_group_stom_agg(
     Args:
         problem (Problem): the problem the scalarization is added to.
         symbol (str): the symbol given to the added scalarization.
-        reference_points (list[dict[str, float]]): a list of dicts with keys corresponding to objective
-            function symbols and values to reference point components, i.e.,
-            aspiration levels.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_aspirations (dict[str, float]): a dictionary of aggregated aspiration levels, i.e., min aspirations.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
         rho (float, optional): a small scalar value to scale the sum in the objective
@@ -1990,7 +1986,6 @@ def add_group_stom_agg(
         tuple[Problem, str]: a tuple with the copy of the problem with the added
             scalarization and the symbol of the added scalarization.
     """
-
     # check if ideal point is specified
     # if not specified, try to calculate corrected ideal point
     if ideal is not None:
@@ -2097,7 +2092,7 @@ def add_group_stom_diff(
             aspiration levels.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         rho (float, optional): a small scalar value to scale the sum in the objective
             function of the scalarization. Defaults to 1e-6.
         delta (float, optional): a small scalar value to define the utopian point. Defaults to 1e-6.
@@ -2161,7 +2156,8 @@ def add_group_stom_diff(
         for obj in problem.objectives:
             if type(delta) is dict:
                 rp[obj.symbol] = (
-                    f"{weights[i][obj.symbol]} * ({obj.symbol}_min - {ideal_point[obj.symbol] - delta[obj.symbol]}) - _alpha"
+                    f"{weights[i][obj.symbol]} * ({obj.symbol}_min - {ideal_point[obj.symbol] - delta[obj.symbol]})"
+                    " - _alpha"
                 )
             else:
                 rp[obj.symbol] = (
@@ -2250,12 +2246,10 @@ def add_group_stom_agg_diff(
     Args:
         problem (Problem): the problem the scalarization is added to.
         symbol (str): the symbol given to the added scalarization.
-        reference_points (list[dict[str, float]]): a list of dicts with keys corresponding to objective
-            function symbols and values to reference point components, i.e.,
-            aspiration levels.
+        agg_aspirations (dict[str, float]): a dictionary of aggregated aspiration levels, i.e., min aspirations.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         rho (float, optional): a small scalar value to scale the sum in the objective
             function of the scalarization. Defaults to 1e-6.
         delta (float, optional): a small scalar value to define the utopian point. Defaults to 1e-6.
@@ -2267,7 +2261,6 @@ def add_group_stom_agg_diff(
         tuple[Problem, str]: a tuple with the copy of the problem with the added
             scalarization and the symbol of the added scalarization.
     """
-
     # check if ideal point is specified
     # if not specified, try to calculate corrected ideal point
     if ideal is not None:
@@ -2400,7 +2393,7 @@ def add_group_guess(
         reference_points (list[dict[str, float]]): a list of dicts with keys corresponding to objective
             function symbols and values to reference point components, i.e.,
             aspiration levels.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
             to calculate nadir point from problem.
         rho (float, optional): a small scalar value to scale the sum in the objective
@@ -2528,11 +2521,11 @@ def add_group_guess_agg(
     Args:
         problem (Problem): the problem the scalarization is added to.
         symbol (str): the symbol given to the added scalarization.
-        reference_points (list[dict[str, float]]): a list of dicts with keys corresponding to objective
-            function symbols and values to reference point components, i.e.,
-            aspiration levels.
+        agg_aspirations (dict[str, float]): a dictionary of aggregated aspiration levels, i.e., min aspirations.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         ideal (dict[str, float], optional): ideal point values. If not given, attempt will be made
             to calculate ideal point from problem.
+        nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
         rho (float, optional): a small scalar value to scale the sum in the objective
             function of the scalarization. Defaults to 1e-6.
         delta (float, optional): a small scalar value to define the utopian point. Defaults to 1e-6.
@@ -2544,7 +2537,6 @@ def add_group_guess_agg(
         tuple[Problem, str]: a tuple with the copy of the problem with the added
             scalarization and the symbol of the added scalarization.
     """
-
     # check if ideal point is specified
     # if not specified, try to calculate corrected ideal point
     if ideal is not None:
@@ -2661,7 +2653,7 @@ def add_group_guess_diff(
             aspiration levels.
         nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
             to calculate nadir point from problem.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         rho (float, optional): a small scalar value to scale the sum in the objective
             function of the scalarization. Defaults to 1e-6.
         delta (float, optional): a small scalar to define the utopian point. Defaults to 1e-6.
@@ -2726,7 +2718,8 @@ def add_group_guess_diff(
         for obj in problem.objectives:
             if type(delta) is dict:
                 rp[obj.symbol] = (
-                    f"{weights[i][obj.symbol]} * ({obj.symbol}_min - {nadir_point[obj.symbol] + delta[obj.symbol]}) - _alpha"
+                    f"{weights[i][obj.symbol]} * ({obj.symbol}_min - {nadir_point[obj.symbol] + delta[obj.symbol]})"
+                    " - _alpha"
                 )
             else:
                 rp[obj.symbol] = (
@@ -2815,12 +2808,10 @@ def add_group_guess_agg_diff(
     Args:
         problem (Problem): the problem the scalarization is added to.
         symbol (str): the symbol given to the added scalarization.
-        reference_points (list[dict[str, float]]): a list of dicts with keys corresponding to objective
-            function symbols and values to reference point components, i.e.,
-            aspiration levels.
+        agg_aspirations (dict[str, float]): a dictionary of aggregated aspiration levels, i.e., min aspirations.
         nadir (dict[str, float], optional): nadir point values. If not given, attempt will be made
             to calculate nadir point from problem.
-        agg_bounds dict[str, float]: a dictionary of bounds not to violate.
+        agg_bounds (dict[str, float]): a dictionary of bounds not to violate.
         rho (float, optional): a small scalar value to scale the sum in the objective
             function of the scalarization. Defaults to 1e-6.
         delta (float, optional): a small scalar to define the utopian point. Defaults to 1e-6.
@@ -2832,7 +2823,6 @@ def add_group_guess_agg_diff(
         tuple[Problem, str]: a tuple with the copy of the problem with the added
             scalarization and the symbol of the added scalarization.
     """
-
     # check if nadir point is specified
     # if not specified, try to calculate corrected nadir point
     if nadir is not None:

--- a/desdeo/tools/gurobipy_solver_interfaces.py
+++ b/desdeo/tools/gurobipy_solver_interfaces.py
@@ -285,8 +285,8 @@ def check_gurobi_license():
     """Check if Gurobi is using a full license (not trial).
 
     Returns:
-        True if using full academic/commercial license
-        False if using trial license or no license found
+        (str | bool): True if using full academic/commercial license
+            False if using trial license or no license found
     """
     captured_output = io.StringIO()
     original_stdout = sys.stdout

--- a/desdeo/tools/scenarios.py
+++ b/desdeo/tools/scenarios.py
@@ -176,8 +176,8 @@ def _combine_elements(
     scenario_problems: dict[str, Problem],
     var_maps: dict[str, dict[str, str]],
     const_maps: dict[str, dict[str, str]],
-    get_list,
-    make_update,
+    get_list: callable,
+    make_update: callable,
     extra_leaf_maps: "dict[str, dict[str, str]] | None" = None,
 ) -> tuple[list | None, dict[str, dict[str, str]]]:
     """Build a combined list for one element type across all leaf scenarios.
@@ -274,7 +274,7 @@ def build_scenario_problem(scenario_model: "ScenarioModel", scenario_name: str) 
 def solve_scenario(
     scenario_model: "ScenarioModel",
     scenario_name: str,
-    solver_callable,
+    solver_callable: callable,
     solver_options: dict | None = None,
 ) -> "SolverResults":
     """Solve a single scenario.
@@ -298,7 +298,7 @@ def solve_scenario(
 
 def solve_all_scenarios(
     scenario_model: "ScenarioModel",
-    solver_callable,
+    solver_callable: callable,
     solver_options: dict | None = None,
 ) -> dict[str, "SolverResults"]:
     """Solve every leaf scenario in the model independently.
@@ -341,9 +341,9 @@ def build_combined_scenario_problem(
         A tuple of:
         - A single Problem suitable for passing directly to a solver.
         - A symbol map ``{element_type: {original_symbol: {leaf: new_symbol}}}``.
-          Element types are ``"variables"``, ``"constants"``, ``"objectives"``,
-          ``"constraints"``, ``"extra_funcs"``, and ``"scalarization_funcs"``.
-          Leaves that do not carry a given element retain the original symbol.
+            Element types are ``"variables"``, ``"constants"``, ``"objectives"``,
+            ``"constraints"``, ``"extra_funcs"``, and ``"scalarization_funcs"``.
+            Leaves that do not carry a given element retain the original symbol.
 
     Raises:
         ValueError: if the model contains no leaf scenarios.

--- a/docs/api/desdeo_tools.md
+++ b/docs/api/desdeo_tools.md
@@ -89,7 +89,7 @@
         show_root_heading: false
 
 ## Reference point generation
-::: desdeo.tools.GenerateReferencePoints
+::: desdeo.tools.generateReferencePoints
     options:
         heading_level: 3
         show_root_heading: false

--- a/docs/howtoguides/IPR.ipynb
+++ b/docs/howtoguides/IPR.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "from desdeo.problem.testproblems import forest_problem\n",
     "from desdeo.tools import GurobipySolver, payoff_table_method\n",
-    "from desdeo.tools.GenerateReferencePoints import generate_points\n",
+    "from desdeo.tools.generateReferencePoints import generate_points\n",
     "from desdeo.tools.iterative_pareto_representer import _EvaluatedPoint, choose_reference_point\n",
     "from desdeo.tools.scalarization import add_asf_diff"
    ]


### PR DESCRIPTION
Fixed the griffe warnings #519 
Tried to please Ruff, but it complains too much. I'm not paid enough to rewrite Nimbus functions to be less complex :DD
Also, after going through what I was able to fix for Ruff, it came up with more complaints.
Renamed GenerateReferencePoints.py to generateReferencePoints.py
About 8 tests now pass that were caused by what seemed to be incomplete changing of how the gurobipy_evaluator.init_constraints worked. The documentation and some of the calls for it seem to be outdated though.