### PR TITLE
Add Lamé superspheres test problem

### DIFF
--- a/desdeo/problem/testproblems/__init__.py
+++ b/desdeo/problem/testproblems/__init__.py
@@ -54,6 +54,7 @@ __all__ = [  # noqa: RUF022
     "summer_cabin_battery_problem",
     "summer_cabin_battery_problem_split",
     "summer_cabin_battery_problem_split_scenario",
+    "lame_superspheres",   
 ]
 
 
@@ -105,3 +106,4 @@ from .summer_cabin_electricity import (
     summer_cabin_battery_problem_split_scenario,
 )
 from .zdt_problem import zdt1, zdt2, zdt3, zdt4, zdt6
+from .lame_superspheres_problem import lame_superspheres

--- a/desdeo/problem/testproblems/lame_superspheres_problem.py
+++ b/desdeo/problem/testproblems/lame_superspheres_problem.py
@@ -1,0 +1,151 @@
+"""Contains Lamé superspheres test problems."""
+
+import numpy as np
+
+from desdeo.problem.schema import (
+    ExtraFunction,
+    Objective,
+    Problem,
+    Variable,
+    VariableTypeEnum,
+)
+
+
+def lame_superspheres(
+    n_variables: int,
+    n_objectives: int,
+    gamma: float = 2.0,
+) -> Problem:
+    r"""Defines the Lamé superspheres test problem.
+
+    The objective functions for the Lamé superspheres problem are defined
+    as follows, for $i = 1$ to $M$:
+
+    \begin{equation}
+    f_i(\mathbf{x})
+    =
+    (1 + g(\mathbf{x}_M))
+    \tilde{p}_i(\mathbf{x}),
+    \end{equation}
+
+    where the angular terms are
+
+    \begin{equation}
+    \tilde{p}_1 =
+    \prod_{j=1}^{M-1}
+    \cos\left(x_j \frac{\pi}{2}\right)^{2/\gamma},
+    \end{equation}
+
+    and for $i > 1$
+
+    \begin{equation}
+    \tilde{p}_i =
+    \left(
+    \prod_{j=1}^{M-i}
+    \cos\left(x_j \frac{\pi}{2}\right)
+    \right)^{2/\gamma}
+    \sin\left(
+    x_{M-i+1}
+    \frac{\pi}{2}
+    \right)^{2/\gamma}.
+    \end{equation}
+
+    The distance function is
+
+    \begin{equation}
+    g(\mathbf{x}_M)
+    =
+    \sum_{x_i \in \mathbf{x}_M}
+    \left(x_i - 0.5\right)^2.
+    \end{equation}
+
+    The parameter $\gamma$ controls the curvature of the Pareto front:
+
+    - $\gamma = 2$ gives a spherical front.
+    - $\gamma < 2$ gives a more convex front.
+    - $\gamma > 2$ gives a more concave front.
+
+    Args:
+        n_variables: Number of variables.
+        n_objectives: Number of objectives.
+        gamma: Lamé exponent controlling front curvature.
+
+    Returns:
+        Problem: A Lamé superspheres test problem.
+
+    References:
+        Emmerich, M. T. M., & Deutz, A. H. (2007).
+        Test Problems Based on Lamé Superspheres.
+        EMO 2007, LNCS 4403, 922–936.
+    """
+
+    g_symbol = "g"
+    g_expr = " + ".join(
+        [f"(x_{i} - 0.5)**2" for i in range(n_objectives, n_variables + 1)]
+    )
+
+    objectives = []
+
+    for m in range(1, n_objectives + 1):
+        prod_expr = " * ".join(
+            [
+                f"Cos(0.5 * {np.pi} * x_{i})**({2 / gamma})"
+                for i in range(1, n_objectives - m + 1)
+            ]
+        )
+
+        if m > 1:
+            prod_expr += (
+                f"{' * ' if prod_expr != '' else ''}"
+                f"Sin(0.5 * {np.pi} * x_{n_objectives - m + 1})**({2 / gamma})"
+            )
+
+        if prod_expr == "":
+            prod_expr = "1"
+
+        f_m_expr = f"(1 + {g_symbol}) * ({prod_expr})"
+
+        objectives.append(
+            Objective(
+                name=f"f_{m}",
+                symbol=f"f_{m}",
+                func=f_m_expr,
+                maximize=False,
+                ideal=0,
+                nadir=1,
+                is_convex=False,
+                is_linear=False,
+                is_twice_differentiable=True,
+            )
+        )
+
+    variables = [
+        Variable(
+            name=f"x_{i}",
+            symbol=f"x_{i}",
+            variable_type=VariableTypeEnum.real,
+            lowerbound=0,
+            upperbound=1,
+            initial_value=1.0,
+        )
+        for i in range(1, n_variables + 1)
+    ]
+
+    extras = [
+        ExtraFunction(
+            name="g",
+            symbol=g_symbol,
+            func=g_expr,
+            is_convex=False,
+            is_linear=False,
+            is_twice_differentiable=True,
+        ),
+    ]
+
+    return Problem(
+        name="lame_superspheres",
+        description="Lamé superspheres test problem.",
+        variables=variables,
+        objectives=objectives,
+        extra_funcs=extras,
+    )

--- a/desdeo/problem/testproblems/lame_superspheres_problem.py
+++ b/desdeo/problem/testproblems/lame_superspheres_problem.py
@@ -28,26 +28,34 @@ def lame_superspheres(
     \tilde{p}_i(\mathbf{x}),
     \end{equation}
 
-    where the angular terms are
+    where the hypersphere parametrization follows Eq. (10)
 
     \begin{equation}
-    \tilde{p}_1 =
-    \prod_{j=1}^{M-1}
-    \cos\left(x_j \frac{\pi}{2}\right)^{2/\gamma},
+    p_1 = \cos(\theta_1),
     \end{equation}
 
-    and for $i > 1$
+    \begin{equation}
+    p_2 = \sin(\theta_1)\cos(\theta_2),
+    \end{equation}
 
     \begin{equation}
-    \tilde{p}_i =
-    \left(
-    \prod_{j=1}^{M-i}
-    \cos\left(x_j \frac{\pi}{2}\right)
-    \right)^{2/\gamma}
-    \sin\left(
-    x_{M-i+1}
-    \frac{\pi}{2}
-    \right)^{2/\gamma}.
+    p_3 = \sin(\theta_1)\sin(\theta_2)\cos(\theta_3),
+    \end{equation}
+
+    \begin{equation}
+    \vdots
+    \end{equation}
+
+    \begin{equation}
+    p_M =
+    \prod_{j=1}^{M-1}
+    \sin(\theta_j).
+    \end{equation}
+
+    The Lamé supersphere coordinates are then obtained as
+
+    \begin{equation}
+    \tilde{p}_i = p_i^{2/\gamma}.
     \end{equation}
 
     The distance function is
@@ -55,15 +63,18 @@ def lame_superspheres(
     \begin{equation}
     g(\mathbf{x}_M)
     =
+    \sqrt{
     \sum_{x_i \in \mathbf{x}_M}
-    \left(x_i - 0.5\right)^2.
+    x_i^2
+    }.
     \end{equation}
 
     The parameter $\gamma$ controls the curvature of the Pareto front:
 
-    - $\gamma = 2$ gives a spherical front.
-    - $\gamma < 2$ gives a more convex front.
-    - $\gamma > 2$ gives a more concave front.
+    - $\gamma < 1$ gives a convex Pareto front.
+    - $\gamma = 1$ gives a linear Pareto front.
+    - $\gamma = 2$ gives a spherical (concave) Pareto front.
+    - $\gamma > 2$ gives a more boxy, strongly concave Pareto front.
 
     Args:
         n_variables: Number of variables.
@@ -80,31 +91,47 @@ def lame_superspheres(
     """
 
     g_symbol = "g"
-    g_expr = " + ".join(
-        [f"(x_{i} - 0.5)**2" for i in range(n_objectives, n_variables + 1)]
+
+    sum_expr = " + ".join(
+        [f"(x_{i})**2" for i in range(n_objectives, n_variables + 1)]
     )
 
+    g_expr = f"Sqrt({sum_expr})"
     objectives = []
 
     for m in range(1, n_objectives + 1):
-        prod_expr = " * ".join(
-            [
-                f"Cos(0.5 * {np.pi} * x_{i})**({2 / gamma})"
-                for i in range(1, n_objectives - m + 1)
+
+        if m == 1:
+
+            angular_expr = f"Cos(0.5 * {np.pi} * x_1)"
+
+        elif m < n_objectives:
+    
+            factors = [
+                f"Sin(0.5 * {np.pi} * x_{i})"
+                for i in range(1, m)
             ]
-        )
-
-        if m > 1:
-            prod_expr += (
-                f"{' * ' if prod_expr != '' else ''}"
-                f"Sin(0.5 * {np.pi} * x_{n_objectives - m + 1})**({2 / gamma})"
+    
+            factors.append(
+                f"Cos(0.5 * {np.pi} * x_{m})"
             )
-
-        if prod_expr == "":
-            prod_expr = "1"
-
-        f_m_expr = f"(1 + {g_symbol}) * ({prod_expr})"
-
+    
+            angular_expr = " * ".join(factors)
+    
+        else:
+    
+            angular_expr = " * ".join(
+                [
+                    f"Sin(0.5 * {np.pi} * x_{i})"
+                    for i in range(1, n_objectives)
+                ]
+            )
+    
+        f_m_expr = (
+            f"(1 + {g_symbol}) * "
+            f"(({angular_expr})**({2 / gamma}))"
+        )
+    
         objectives.append(
             Objective(
                 name=f"f_{m}",

--- a/desdeo/problem/testproblems/lame_superspheres_problem.py
+++ b/desdeo/problem/testproblems/lame_superspheres_problem.py
@@ -76,7 +76,7 @@ def lame_superspheres(
     References:
         Emmerich, M. T. M., & Deutz, A. H. (2007).
         Test Problems Based on Lamé Superspheres.
-        EMO 2007, LNCS 4403, 922–936.
+        EMO 2007, LNCS 4403, 922-936.
     """
 
     g_symbol = "g"

--- a/tests/test_testproblems.py
+++ b/tests/test_testproblems.py
@@ -10,6 +10,7 @@ from desdeo.problem.testproblems import (
     binh_and_korn,
     dtlz2,
     dtlz4,
+    lame_superspheres,
     forest_problem,
     mcwb_equilateral_tbeam_problem,
     mcwb_hollow_rectangular_problem,
@@ -96,6 +97,34 @@ def test_dtlz4():
 
     f1 = res["f_1"]
     assert np.isclose(f1, 1.0075)
+    
+    
+@pytest.mark.testproblem
+def test_lame_superspheres():
+    """Test that the Lamé superspheres problem initializes and evaluates correctly."""
+
+    problem = lame_superspheres(
+        n_variables=5,
+        n_objectives=3,
+        gamma=2.0,
+    )
+
+    assert len(problem.variables) == 5
+    assert len(problem.objectives) == 3
+
+    xs = {f"{var.symbol}": [0.5] for var in problem.variables}
+
+    evaluator = PolarsEvaluator(problem)
+
+    res = evaluator.evaluate(xs)
+
+    f1 = res["f_1"][0]
+    f2 = res["f_2"][0]
+    f3 = res["f_3"][0]
+
+    assert np.isfinite(f1)
+    assert np.isfinite(f2)
+    assert np.isfinite(f3)
 
 
 @pytest.mark.testproblem


### PR DESCRIPTION
## Summary

This PR adds the Lamé superspheres test problem family to DESDEO.

The implementation follows the scalable test-problem structure used by the existing DTLZ problems and exposes the Lamé exponent (`gamma`) as a parameter to control the curvature of the Pareto front.

## Changes

- Added `lame_superspheres()` in `desdeo/problem/testproblems/lame_superspheres_problem.py`
- Added configurable `gamma` parameter for front curvature
- Added mathematical documentation in LaTeX format
- Registered the problem in `desdeo/problem/testproblems/__init__.py`
- Added a test case in `tests/test_testproblems.py`

## Validation

Executed:

python -m pytest tests/test_testproblems.py::test_lame_superspheres -v

Result:

1 passed

## Reference

Emmerich, M. T. M., & Deutz, A. H. (2007).
Test Problems Based on Lamé Superspheres.
Evolutionary Multi-Criterion Optimization (EMO 2007),
LNCS 4403, pp. 922–936.