### PR TITLE
Fix typos in the documentation

### DIFF
--- a/desdeo/api/README.md
+++ b/desdeo/api/README.md
@@ -17,7 +17,7 @@ To initialize the database, run the script `db_init.py` with the following comma
 python db_init.py
 ```
 
-This will create an initial databse, which allows testing for, e.g., testing
+This will create an initial database, which allows testing for, e.g., testing
 the databse. However, the tests themselves (see below), do not depend on this
 database, and handle the database for running the tests on their own.
 

--- a/docs/explanation/scenarios.md
+++ b/docs/explanation/scenarios.md
@@ -314,7 +314,7 @@ summer_cabin_scenarios = ScenarioModel(
 
 # Using scenario models
 
-Currently, there are two ways of using scenario models withing DESDEO: constructing Problems corresponding to individual scenarios and building aggregate problems consisting of multiple scenarios.
+Currently, there are two ways of using scenario models within DESDEO: constructing Problems corresponding to individual scenarios and building aggregate problems consisting of multiple scenarios.
 
 You can construct individual scenario problems by calling the `get_scenario_problem` function. This is unlikely to be that useful on its own, but can be useful for sanity checks or for constructing more complex methods.
 

--- a/docs/howtoguides/kubernetes.md
+++ b/docs/howtoguides/kubernetes.md
@@ -17,7 +17,7 @@ Once you have your project set up, you can start adding resources to your projec
 
 To add a new resource i.e. piece of your web application, navigate to the `+Add` page. There, you want to choose `Import from Git` option.
 
-First, you will need to input a Github adress to the repository that contains your DESDEO webapi code, for example `https://github.com/industrial-optimization-group/DESDEO`. You are unlikely to be using the main branch of the Git for your deployment, so click `Show advanced Git options` and add the name of your desired branch under `Git reference`. You probably don't need to touch any of the other advanced options.
+First, you will need to input a Github address to the repository that contains your DESDEO webapi code, for example `https://github.com/industrial-optimization-group/DESDEO`. You are unlikely to be using the main branch of the Git for your deployment, so click `Show advanced Git options` and add the name of your desired branch under `Git reference`. You probably don't need to touch any of the other advanced options.
 
 At this point, the system should have automatically figured out that you want to host a Python application and chosen you an appropriate `Builder Image version`. But if not, you can set it up manually.
 !!! Note


### PR DESCRIPTION
Fixes 3 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, dependency names or proper nouns changed.